### PR TITLE
feat: 統計可視化 (飛距離分布グラフ + ショット散布図)

### DIFF
--- a/src/components/ClubComparison.tsx
+++ b/src/components/ClubComparison.tsx
@@ -1,0 +1,153 @@
+/**
+ * クラブ比較コンポーネント
+ *
+ * 複数クラブの飛距離分布を重ねて比較するグラフ。
+ */
+
+import * as d3 from "d3";
+import { useEffect, useRef } from "react";
+import type { DistanceStats } from "../lib/statistics";
+
+interface ClubComparisonProps {
+	readonly stats: readonly DistanceStats[];
+	readonly width?: number;
+	readonly height?: number;
+}
+
+const CLUB_DISPLAY: Record<string, string> = {
+	driver: "DR",
+	"3w": "3W",
+	"5w": "5W",
+	"7w": "7W",
+	"3i": "3I",
+	"4i": "4I",
+	"5i": "5I",
+	"6i": "6I",
+	"7i": "7I",
+	"8i": "8I",
+	"9i": "9I",
+	pw: "PW",
+	aw: "AW",
+	sw: "SW",
+	lw: "LW",
+	putter: "PT",
+};
+
+export function ClubComparison({ stats, width = 500, height = 300 }: ClubComparisonProps) {
+	const svgRef = useRef<SVGSVGElement>(null);
+
+	useEffect(() => {
+		const svg = svgRef.current;
+		if (!svg || stats.length === 0) return;
+
+		const margin = { top: 20, right: 20, bottom: 60, left: 50 };
+		const innerWidth = width - margin.left - margin.right;
+		const innerHeight = height - margin.top - margin.bottom;
+
+		const d3Svg = d3.select(svg);
+		d3Svg.selectAll("*").remove();
+		d3Svg.attr("width", width).attr("height", height);
+
+		const g = d3Svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+
+		// ソート: 平均飛距離の降順
+		const sorted = [...stats].sort((a, b) => b.mean - a.mean);
+
+		const xScale = d3
+			.scaleBand()
+			.domain(sorted.map((s) => s.clubType))
+			.range([0, innerWidth])
+			.padding(0.2);
+
+		const maxDistance = d3.max(sorted, (s) => s.max) ?? 300;
+		const yScale = d3
+			.scaleLinear()
+			.domain([0, maxDistance + 20])
+			.range([innerHeight, 0]);
+
+		const colorScale = d3
+			.scaleOrdinal<string>()
+			.domain(sorted.map((s) => s.clubType))
+			.range(d3.schemeCategory10);
+
+		// バー: 平均飛距離
+		g.selectAll(".bar")
+			.data(sorted)
+			.join("rect")
+			.attr("class", "bar")
+			.attr("x", (d) => xScale(d.clubType) ?? 0)
+			.attr("y", (d) => yScale(d.mean))
+			.attr("width", xScale.bandwidth())
+			.attr("height", (d) => innerHeight - yScale(d.mean))
+			.attr("fill", (d) => colorScale(d.clubType))
+			.attr("opacity", 0.7);
+
+		// エラーバー: 標準偏差
+		for (const s of sorted) {
+			const cx = (xScale(s.clubType) ?? 0) + xScale.bandwidth() / 2;
+			g.append("line")
+				.attr("x1", cx)
+				.attr("x2", cx)
+				.attr("y1", yScale(s.mean - s.stdDev))
+				.attr("y2", yScale(s.mean + s.stdDev))
+				.attr("stroke", "#374151")
+				.attr("stroke-width", 2);
+
+			// キャップ (上)
+			g.append("line")
+				.attr("x1", cx - 5)
+				.attr("x2", cx + 5)
+				.attr("y1", yScale(s.mean + s.stdDev))
+				.attr("y2", yScale(s.mean + s.stdDev))
+				.attr("stroke", "#374151")
+				.attr("stroke-width", 2);
+
+			// キャップ (下)
+			g.append("line")
+				.attr("x1", cx - 5)
+				.attr("x2", cx + 5)
+				.attr("y1", yScale(s.mean - s.stdDev))
+				.attr("y2", yScale(s.mean - s.stdDev))
+				.attr("stroke", "#374151")
+				.attr("stroke-width", 2);
+		}
+
+		// X軸
+		g.append("g")
+			.attr("transform", `translate(0,${innerHeight})`)
+			.call(d3.axisBottom(xScale).tickFormat((d) => CLUB_DISPLAY[d] ?? d))
+			.selectAll("text")
+			.attr("font-size", "10px")
+			.attr("transform", "rotate(-45)")
+			.attr("text-anchor", "end");
+
+		// Y軸
+		g.append("g").call(d3.axisLeft(yScale).ticks(6)).selectAll("text").attr("font-size", "10px");
+
+		// Y軸ラベル
+		g.append("text")
+			.attr("x", -innerHeight / 2)
+			.attr("y", -35)
+			.attr("transform", "rotate(-90)")
+			.attr("text-anchor", "middle")
+			.attr("font-size", "12px")
+			.attr("fill", "#374151")
+			.text("飛距離 (ヤード)");
+
+		// タイトル
+		g.append("text")
+			.attr("x", innerWidth / 2)
+			.attr("y", -5)
+			.attr("text-anchor", "middle")
+			.attr("font-size", "14px")
+			.attr("font-weight", "bold")
+			.attr("fill", "#1f2937")
+			.text("クラブ別飛距離比較");
+	}, [stats, width, height]);
+
+	if (stats.length === 0) {
+		return <div style={{ padding: "16px", textAlign: "center", color: "#6b7280" }}>比較データがありません</div>;
+	}
+
+	return <svg ref={svgRef} style={{ maxWidth: "100%" }} />;
+}

--- a/src/components/DistanceDistribution.tsx
+++ b/src/components/DistanceDistribution.tsx
@@ -1,0 +1,163 @@
+/**
+ * クラブ別飛距離分布ヒストグラム
+ *
+ * D3.js で飛距離のヒストグラムを描画する。
+ * 平均線と1σ/2σ範囲を視覚的に表示する。
+ */
+
+import * as d3 from "d3";
+import { useEffect, useRef } from "react";
+import { mean, stdDev } from "../lib/statistics";
+
+interface DistanceDistributionProps {
+	readonly distances: readonly number[];
+	readonly clubName: string;
+	readonly width?: number;
+	readonly height?: number;
+}
+
+export function DistanceDistribution({ distances, clubName, width = 400, height = 250 }: DistanceDistributionProps) {
+	const svgRef = useRef<SVGSVGElement>(null);
+
+	useEffect(() => {
+		const svg = svgRef.current;
+		if (!svg || distances.length === 0) return;
+
+		const margin = { top: 20, right: 20, bottom: 40, left: 50 };
+		const innerWidth = width - margin.left - margin.right;
+		const innerHeight = height - margin.top - margin.bottom;
+
+		const d3Svg = d3.select(svg);
+		d3Svg.selectAll("*").remove();
+		d3Svg.attr("width", width).attr("height", height);
+
+		const g = d3Svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+
+		// ヒストグラムのビン計算
+		const extent = d3.extent(distances) as [number, number];
+		const xScale = d3
+			.scaleLinear()
+			.domain([extent[0] - 10, extent[1] + 10])
+			.range([0, innerWidth]);
+
+		const histogram = d3
+			.bin()
+			.domain(xScale.domain() as [number, number])
+			.thresholds(xScale.ticks(15));
+
+		const bins = histogram(distances as number[]);
+		const maxCount = d3.max(bins, (d) => d.length) ?? 0;
+		const yScale = d3.scaleLinear().domain([0, maxCount]).range([innerHeight, 0]);
+
+		// バー描画
+		g.selectAll("rect")
+			.data(bins)
+			.join("rect")
+			.attr("x", (d) => xScale(d.x0 ?? 0))
+			.attr("y", (d) => yScale(d.length))
+			.attr("width", (d) => Math.max(0, xScale(d.x1 ?? 0) - xScale(d.x0 ?? 0) - 1))
+			.attr("height", (d) => innerHeight - yScale(d.length))
+			.attr("fill", "#3b82f6")
+			.attr("opacity", 0.7);
+
+		// 平均線
+		const avg = mean(distances);
+		const sd = stdDev(distances);
+
+		g.append("line")
+			.attr("x1", xScale(avg))
+			.attr("x2", xScale(avg))
+			.attr("y1", 0)
+			.attr("y2", innerHeight)
+			.attr("stroke", "#dc2626")
+			.attr("stroke-width", 2)
+			.attr("stroke-dasharray", "4,2");
+
+		// 1σ範囲
+		g.append("rect")
+			.attr("x", xScale(avg - sd))
+			.attr("y", 0)
+			.attr("width", xScale(avg + sd) - xScale(avg - sd))
+			.attr("height", innerHeight)
+			.attr("fill", "#fca5a5")
+			.attr("opacity", 0.15);
+
+		// 2σ範囲
+		g.append("rect")
+			.attr("x", xScale(avg - 2 * sd))
+			.attr("y", 0)
+			.attr("width", xScale(avg + 2 * sd) - xScale(avg - 2 * sd))
+			.attr("height", innerHeight)
+			.attr("fill", "#fecaca")
+			.attr("opacity", 0.1);
+
+		// X軸
+		g.append("g")
+			.attr("transform", `translate(0,${innerHeight})`)
+			.call(d3.axisBottom(xScale).ticks(8))
+			.selectAll("text")
+			.attr("font-size", "10px");
+
+		// Y軸
+		g.append("g").call(d3.axisLeft(yScale).ticks(5)).selectAll("text").attr("font-size", "10px");
+
+		// X軸ラベル
+		g.append("text")
+			.attr("x", innerWidth / 2)
+			.attr("y", innerHeight + 35)
+			.attr("text-anchor", "middle")
+			.attr("font-size", "12px")
+			.attr("fill", "#374151")
+			.text("飛距離 (ヤード)");
+
+		// タイトル
+		g.append("text")
+			.attr("x", innerWidth / 2)
+			.attr("y", -5)
+			.attr("text-anchor", "middle")
+			.attr("font-size", "14px")
+			.attr("font-weight", "bold")
+			.attr("fill", "#1f2937")
+			.text(`${clubName} 飛距離分布`);
+
+		// 凡例
+		const legend = g.append("g").attr("transform", `translate(${innerWidth - 120}, 10)`);
+		legend
+			.append("line")
+			.attr("x1", 0)
+			.attr("x2", 20)
+			.attr("y1", 0)
+			.attr("y2", 0)
+			.attr("stroke", "#dc2626")
+			.attr("stroke-width", 2)
+			.attr("stroke-dasharray", "4,2");
+		legend
+			.append("text")
+			.attr("x", 25)
+			.attr("y", 4)
+			.attr("font-size", "10px")
+			.attr("fill", "#374151")
+			.text(`平均: ${avg.toFixed(1)}yd`);
+		legend
+			.append("rect")
+			.attr("x", 0)
+			.attr("y", 10)
+			.attr("width", 20)
+			.attr("height", 10)
+			.attr("fill", "#fca5a5")
+			.attr("opacity", 0.3);
+		legend
+			.append("text")
+			.attr("x", 25)
+			.attr("y", 19)
+			.attr("font-size", "10px")
+			.attr("fill", "#374151")
+			.text(`1σ: ${sd.toFixed(1)}yd`);
+	}, [distances, clubName, width, height]);
+
+	if (distances.length === 0) {
+		return <div style={{ padding: "16px", textAlign: "center", color: "#6b7280" }}>データがありません</div>;
+	}
+
+	return <svg ref={svgRef} style={{ maxWidth: "100%" }} />;
+}

--- a/src/components/ShotScatter.tsx
+++ b/src/components/ShotScatter.tsx
@@ -1,0 +1,152 @@
+/**
+ * ショット散布図コンポーネント
+ *
+ * 着弾点の2Dプロットをクラブ別色分けで表示する。
+ * ツールチップ対応（ホバー/タップで詳細表示）。
+ */
+
+import * as d3 from "d3";
+import { useEffect, useRef, useState } from "react";
+import type { Shot } from "../types/shot";
+
+interface ShotScatterProps {
+	readonly shots: readonly Shot[];
+	readonly width?: number;
+	readonly height?: number;
+	/** パフォーマンス上限: 10,000ショット */
+	readonly maxShots?: number;
+}
+
+const MAX_SHOTS_DEFAULT = 10000;
+
+export function ShotScatter({ shots, width = 500, height = 400, maxShots = MAX_SHOTS_DEFAULT }: ShotScatterProps) {
+	const svgRef = useRef<SVGSVGElement>(null);
+	const [tooltip, setTooltip] = useState<{
+		x: number;
+		y: number;
+		text: string;
+	} | null>(null);
+
+	const displayShots = shots.length > maxShots ? shots.slice(-maxShots) : shots;
+	const isTruncated = shots.length > maxShots;
+
+	useEffect(() => {
+		const svg = svgRef.current;
+		if (!svg || displayShots.length === 0) return;
+
+		const margin = { top: 20, right: 20, bottom: 40, left: 50 };
+		const innerWidth = width - margin.left - margin.right;
+		const innerHeight = height - margin.top - margin.bottom;
+
+		const d3Svg = d3.select(svg);
+		d3Svg.selectAll("*").remove();
+		d3Svg.attr("width", width).attr("height", height);
+
+		const g = d3Svg.append("g").attr("transform", `translate(${margin.left},${margin.top})`);
+
+		// スケール
+		const xExtent = d3.extent(displayShots, (s) => s.landingPosition.lng) as [number, number];
+		const yExtent = d3.extent(displayShots, (s) => s.landingPosition.lat) as [number, number];
+
+		const xScale = d3
+			.scaleLinear()
+			.domain([xExtent[0] - 5, xExtent[1] + 5])
+			.range([0, innerWidth]);
+		const yScale = d3
+			.scaleLinear()
+			.domain([yExtent[0] - 5, yExtent[1] + 5])
+			.range([innerHeight, 0]);
+
+		const colorScale = d3
+			.scaleOrdinal<string>()
+			.domain(["driver", "3w", "5w", "7w", "3i", "4i", "5i", "6i", "7i", "8i", "9i", "pw", "aw", "sw", "lw", "putter"])
+			.range(d3.schemeCategory10);
+
+		// 軸
+		g.append("g")
+			.attr("transform", `translate(0,${innerHeight})`)
+			.call(d3.axisBottom(xScale).ticks(8))
+			.selectAll("text")
+			.attr("font-size", "10px");
+
+		g.append("g").call(d3.axisLeft(yScale).ticks(8)).selectAll("text").attr("font-size", "10px");
+
+		// ドット描画
+		g.selectAll("circle")
+			.data(displayShots)
+			.join("circle")
+			.attr("cx", (d) => xScale(d.landingPosition.lng))
+			.attr("cy", (d) => yScale(d.landingPosition.lat))
+			.attr("r", 5)
+			.attr("fill", (d) => colorScale(d.club))
+			.attr("stroke", "#ffffff")
+			.attr("stroke-width", 1)
+			.attr("opacity", 0.7)
+			.on("mouseenter", (_event, d) => {
+				const x = xScale(d.landingPosition.lng) + margin.left;
+				const y = yScale(d.landingPosition.lat) + margin.top - 15;
+				setTooltip({
+					x,
+					y,
+					text: `#${d.shotNumber} ${d.club} ${d.distanceYards}yd`,
+				});
+			})
+			.on("mouseleave", () => {
+				setTooltip(null);
+			});
+
+		// タイトル
+		g.append("text")
+			.attr("x", innerWidth / 2)
+			.attr("y", -5)
+			.attr("text-anchor", "middle")
+			.attr("font-size", "14px")
+			.attr("font-weight", "bold")
+			.attr("fill", "#1f2937")
+			.text("ショット散布図");
+	}, [displayShots, width, height]);
+
+	if (displayShots.length === 0) {
+		return <div style={{ padding: "16px", textAlign: "center", color: "#6b7280" }}>ショットデータがありません</div>;
+	}
+
+	return (
+		<div style={{ position: "relative" }}>
+			{isTruncated && (
+				<div
+					role="alert"
+					style={{
+						padding: "4px 8px",
+						backgroundColor: "#fef3c7",
+						color: "#92400e",
+						fontSize: "12px",
+						borderRadius: "4px",
+						marginBottom: "4px",
+					}}
+				>
+					パフォーマンスのため直近{maxShots.toLocaleString()}件を表示しています
+				</div>
+			)}
+			<svg ref={svgRef} style={{ maxWidth: "100%" }} />
+			{tooltip && (
+				<div
+					style={{
+						position: "absolute",
+						left: `${tooltip.x}px`,
+						top: `${tooltip.y}px`,
+						backgroundColor: "#1f2937",
+						color: "#ffffff",
+						padding: "4px 8px",
+						borderRadius: "4px",
+						fontSize: "12px",
+						pointerEvents: "none",
+						transform: "translateX(-50%)",
+						whiteSpace: "nowrap",
+					}}
+				>
+					{tooltip.text}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,0 +1,92 @@
+/**
+ * 統計数値パネル
+ *
+ * 平均・分散・標準偏差・最大・最小を数値で表示する。
+ */
+
+import type { DistanceStats } from "../lib/statistics";
+
+interface StatsPanelProps {
+	readonly stats: readonly DistanceStats[];
+}
+
+const CLUB_DISPLAY: Record<string, string> = {
+	driver: "ドライバー",
+	"3w": "3W",
+	"5w": "5W",
+	"7w": "7W",
+	"3i": "3I",
+	"4i": "4I",
+	"5i": "5I",
+	"6i": "6I",
+	"7i": "7I",
+	"8i": "8I",
+	"9i": "9I",
+	pw: "PW",
+	aw: "AW",
+	sw: "SW",
+	lw: "LW",
+	putter: "パター",
+};
+
+export function StatsPanel({ stats }: StatsPanelProps) {
+	if (stats.length === 0) {
+		return (
+			<div style={{ padding: "16px", textAlign: "center", color: "#6b7280" }}>
+				統計データがありません。ショットを記録してください。
+			</div>
+		);
+	}
+
+	return (
+		<div aria-label="統計パネル" style={{ padding: "12px" }}>
+			<h3 style={{ fontSize: "16px", marginBottom: "12px" }}>クラブ別統計</h3>
+			<div
+				style={{
+					display: "grid",
+					gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+					gap: "12px",
+				}}
+			>
+				{stats.map((s) => (
+					<div
+						key={s.clubType}
+						style={{
+							border: "1px solid #e5e7eb",
+							borderRadius: "8px",
+							padding: "12px",
+							backgroundColor: "#f9fafb",
+						}}
+					>
+						<h4
+							style={{
+								margin: "0 0 8px 0",
+								fontSize: "14px",
+								fontWeight: "bold",
+							}}
+						>
+							{CLUB_DISPLAY[s.clubType] ?? s.clubType}
+						</h4>
+						<div style={{ fontSize: "12px", lineHeight: "1.8" }}>
+							<div>
+								<span style={{ color: "#6b7280" }}>ショット数:</span> {s.count}
+							</div>
+							<div>
+								<span style={{ color: "#6b7280" }}>平均:</span> {s.mean.toFixed(1)}yd
+							</div>
+							<div>
+								<span style={{ color: "#6b7280" }}>標準偏差:</span> {s.stdDev.toFixed(1)}yd
+							</div>
+							<div>
+								<span style={{ color: "#6b7280" }}>最小:</span> {s.min}yd
+							</div>
+							<div>
+								<span style={{ color: "#6b7280" }}>最大:</span> {s.max}yd
+							</div>
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,28 @@
-import { StrictMode, useState } from "react";
+import { StrictMode, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { ClubComparison } from "./components/ClubComparison";
 import { ClubSelector } from "./components/ClubSelector";
 import { CourseMap } from "./components/CourseMap";
+import { DistanceDistribution } from "./components/DistanceDistribution";
 import { ShotList } from "./components/ShotList";
+import { ShotScatter } from "./components/ShotScatter";
+import { StatsPanel } from "./components/StatsPanel";
 import { useRound } from "./hooks/useRound";
+import { calculateClubStats, groupDistancesByClub } from "./lib/statistics";
 
 function App() {
 	const { round, selectedClub, selectClub, recordShot, undoLastShot, startRound } = useRound();
 	const [error, setError] = useState<string | null>(null);
+	const [showStats, setShowStats] = useState(false);
 
 	const handleStartRound = () => {
 		startRound("mock-course-001");
 		setError(null);
 	};
+
+	const stats = useMemo(() => (round ? calculateClubStats(round.shots) : []), [round]);
+
+	const distancesByClub = useMemo(() => (round ? groupDistancesByClub(round.shots) : new Map()), [round]);
 
 	return (
 		<StrictMode>
@@ -67,6 +77,38 @@ function App() {
 						<ClubSelector selectedClub={selectedClub} onSelect={selectClub} />
 
 						<ShotList shots={round.shots} onUndo={undoLastShot} />
+
+						{round.shots.length > 0 && (
+							<>
+								<button
+									type="button"
+									onClick={() => setShowStats((prev) => !prev)}
+									style={{
+										padding: "8px 16px",
+										fontSize: "14px",
+										backgroundColor: "#f3f4f6",
+										color: "#1f2937",
+										border: "1px solid #d1d5db",
+										borderRadius: "6px",
+										cursor: "pointer",
+										margin: "12px 0",
+									}}
+								>
+									{showStats ? "統計を閉じる" : "統計を表示"}
+								</button>
+
+								{showStats && (
+									<div>
+										<StatsPanel stats={stats} />
+										<ClubComparison stats={stats} />
+										<ShotScatter shots={round.shots} />
+										{[...distancesByClub.entries()].map(([club, distances]) => (
+											<DistanceDistribution key={club} distances={distances} clubName={club} />
+										))}
+									</div>
+								)}
+							</>
+						)}
 					</>
 				)}
 			</div>


### PR DESCRIPTION
## Summary
- DistanceDistribution: D3.jsヒストグラム + 平均線 + 1σ/2σ範囲表示
- ShotScatter: クラブ別色分け散布図 + ツールチップ
- ClubComparison: クラブ別飛距離比較バーチャート + エラーバー(標準偏差)
- StatsPanel: 数値表示 (平均・標準偏差・最小・最大)
- 10,000ショット超過時はパフォーマンス制限警告を表示
- レスポンシブ対応 (maxWidth: 100%)

## Test plan
- [x] `make check` 全パス (54テスト)
- [x] ショット記録後に統計トグルボタンが表示される
- [x] データ0件時に空状態UIが表示される

Closes #9