### PR TITLE
feat: dynamic target coords from course data, round summary UI

### DIFF
--- a/src/components/RoundSummary.tsx
+++ b/src/components/RoundSummary.tsx
@@ -1,0 +1,193 @@
+/**
+ * ラウンド終了サマリーコンポーネント
+ *
+ * ラウンド終了時にスコア集計・クラブ別統計・ベストショット等を表示する。
+ */
+
+import { useMemo } from "react";
+import { calculateClubStats } from "../lib/statistics";
+import type { Round } from "../types/round";
+
+interface RoundSummaryProps {
+	readonly round: Round;
+	readonly courseName: string;
+	readonly onNewRound: () => void;
+}
+
+const CLUB_DISPLAY: Record<string, string> = {
+	driver: "ドライバー",
+	"3w": "3W",
+	"5w": "5W",
+	"7w": "7W",
+	"3i": "3I",
+	"4i": "4I",
+	"5i": "5I",
+	"6i": "6I",
+	"7i": "7I",
+	"8i": "8I",
+	"9i": "9I",
+	pw: "PW",
+	aw: "AW",
+	sw: "SW",
+	lw: "LW",
+	putter: "パター",
+};
+
+export function RoundSummary({ round, courseName, onNewRound }: RoundSummaryProps) {
+	const stats = useMemo(() => calculateClubStats(round.shots), [round.shots]);
+
+	const totalShots = round.shots.length;
+
+	const longestShot = useMemo(() => {
+		if (round.shots.length === 0) return undefined;
+		let best = round.shots[0];
+		for (const shot of round.shots) {
+			if (best && shot.distanceYards > best.distanceYards) {
+				best = shot;
+			}
+		}
+		return best;
+	}, [round.shots]);
+
+	const averageDistance = useMemo(() => {
+		if (round.shots.length === 0) return 0;
+		let sum = 0;
+		for (const shot of round.shots) {
+			sum += shot.distanceYards;
+		}
+		return Math.round(sum / round.shots.length);
+	}, [round.shots]);
+
+	const clubsUsed = useMemo(() => {
+		const clubs = new Set<string>();
+		for (const shot of round.shots) {
+			clubs.add(shot.club);
+		}
+		return clubs.size;
+	}, [round.shots]);
+
+	return (
+		<section
+			aria-label="ラウンドサマリー"
+			style={{
+				border: "2px solid #2563eb",
+				borderRadius: "12px",
+				padding: "20px",
+				backgroundColor: "#f0f9ff",
+			}}
+		>
+			<h2
+				style={{
+					fontSize: "20px",
+					marginBottom: "4px",
+					color: "#1e40af",
+				}}
+			>
+				ラウンド終了
+			</h2>
+			<p style={{ color: "#6b7280", margin: "0 0 16px 0", fontSize: "14px" }}>
+				{courseName} - {new Date(round.date).toLocaleDateString("ja-JP")}
+			</p>
+
+			{/* サマリー数値 */}
+			<div
+				style={{
+					display: "grid",
+					gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+					gap: "12px",
+					marginBottom: "20px",
+				}}
+			>
+				<SummaryCard label="総ショット数" value={String(totalShots)} />
+				<SummaryCard label="使用クラブ数" value={String(clubsUsed)} />
+				<SummaryCard label="平均飛距離" value={`${String(averageDistance)}yd`} />
+				<SummaryCard
+					label="最長飛距離"
+					value={longestShot ? `${String(longestShot.distanceYards)}yd` : "-"}
+					sub={longestShot ? (CLUB_DISPLAY[longestShot.club] ?? longestShot.club) : undefined}
+				/>
+			</div>
+
+			{/* クラブ別統計テーブル */}
+			{stats.length > 0 && (
+				<div style={{ marginBottom: "20px" }}>
+					<h3 style={{ fontSize: "16px", marginBottom: "8px" }}>クラブ別統計</h3>
+					<table
+						style={{
+							width: "100%",
+							borderCollapse: "collapse",
+							fontSize: "13px",
+						}}
+					>
+						<thead>
+							<tr
+								style={{
+									borderBottom: "2px solid #d1d5db",
+									textAlign: "left",
+								}}
+							>
+								<th style={{ padding: "6px 8px" }}>クラブ</th>
+								<th style={{ padding: "6px 8px", textAlign: "right" }}>回数</th>
+								<th style={{ padding: "6px 8px", textAlign: "right" }}>平均</th>
+								<th style={{ padding: "6px 8px", textAlign: "right" }}>標準偏差</th>
+								<th style={{ padding: "6px 8px", textAlign: "right" }}>最長</th>
+							</tr>
+						</thead>
+						<tbody>
+							{stats.map((s) => (
+								<tr key={s.clubType} style={{ borderBottom: "1px solid #e5e7eb" }}>
+									<td style={{ padding: "6px 8px", fontWeight: "bold" }}>{CLUB_DISPLAY[s.clubType] ?? s.clubType}</td>
+									<td style={{ padding: "6px 8px", textAlign: "right" }}>{s.count}</td>
+									<td style={{ padding: "6px 8px", textAlign: "right" }}>{s.mean.toFixed(1)}yd</td>
+									<td style={{ padding: "6px 8px", textAlign: "right" }}>{s.stdDev.toFixed(1)}yd</td>
+									<td style={{ padding: "6px 8px", textAlign: "right" }}>{s.max}yd</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</div>
+			)}
+
+			{totalShots === 0 && (
+				<p style={{ color: "#6b7280", textAlign: "center", padding: "16px" }}>ショットデータがありません。</p>
+			)}
+
+			{/* 新規ラウンドボタン */}
+			<button
+				type="button"
+				onClick={onNewRound}
+				style={{
+					width: "100%",
+					padding: "12px 24px",
+					fontSize: "16px",
+					backgroundColor: "#2563eb",
+					color: "#ffffff",
+					border: "none",
+					borderRadius: "8px",
+					cursor: "pointer",
+				}}
+			>
+				新しいラウンドを開始
+			</button>
+		</section>
+	);
+}
+
+/** サマリーカード小コンポーネント */
+function SummaryCard({ label, value, sub }: { readonly label: string; readonly value: string; readonly sub?: string }) {
+	return (
+		<div
+			style={{
+				backgroundColor: "#ffffff",
+				border: "1px solid #e5e7eb",
+				borderRadius: "8px",
+				padding: "12px",
+				textAlign: "center",
+			}}
+		>
+			<div style={{ fontSize: "12px", color: "#6b7280", marginBottom: "4px" }}>{label}</div>
+			<div style={{ fontSize: "22px", fontWeight: "bold", color: "#1f2937" }}>{value}</div>
+			{sub && <div style={{ fontSize: "11px", color: "#9ca3af", marginTop: "2px" }}>{sub}</div>}
+		</div>
+	);
+}

--- a/src/lib/courses.test.ts
+++ b/src/lib/courses.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { getCourseById, getHoleHazards, getPinPosition, getTeePosition, listCourses } from "./courses";
+
+describe("getCourseById", () => {
+	it("モックコースを取得できる", () => {
+		const course = getCourseById("mock-course-001");
+		expect(course).toBeDefined();
+		expect(course?.name).toBe("サンプルゴルフコース");
+		expect(course?.holes.length).toBeGreaterThan(0);
+	});
+
+	it("存在しないコースIDでundefinedを返す", () => {
+		expect(getCourseById("nonexistent")).toBeUndefined();
+	});
+});
+
+describe("listCourses", () => {
+	it("利用可能なコース一覧を返す", () => {
+		const courses = listCourses();
+		expect(courses.length).toBeGreaterThan(0);
+		const first = courses[0];
+		expect(first).toBeDefined();
+		expect(first?.id).toBe("mock-course-001");
+	});
+});
+
+describe("getPinPosition", () => {
+	it("ホール1のピン位置を返す", () => {
+		const pin = getPinPosition("mock-course-001", 1);
+		expect(pin).toBeDefined();
+		expect(pin?.lat).toBe(75);
+		expect(pin?.lng).toBe(370);
+	});
+
+	it("存在しないホールでundefinedを返す", () => {
+		expect(getPinPosition("mock-course-001", 999)).toBeUndefined();
+	});
+
+	it("存在しないコースでundefinedを返す", () => {
+		expect(getPinPosition("nonexistent", 1)).toBeUndefined();
+	});
+});
+
+describe("getTeePosition", () => {
+	it("ホール1のティー位置を返す", () => {
+		const tee = getTeePosition("mock-course-001", 1);
+		expect(tee).toBeDefined();
+		expect(tee?.lat).toBe(75);
+		expect(tee?.lng).toBe(0);
+	});
+
+	it("存在しないホールでundefinedを返す", () => {
+		expect(getTeePosition("mock-course-001", 999)).toBeUndefined();
+	});
+});
+
+describe("getHoleHazards", () => {
+	it("ホール1のハザード一覧を返す", () => {
+		const hazards = getHoleHazards("mock-course-001", 1);
+		expect(hazards.length).toBe(2);
+		const bunker = hazards.find((h) => h.type === "bunker");
+		expect(bunker).toBeDefined();
+		const water = hazards.find((h) => h.type === "water");
+		expect(water).toBeDefined();
+	});
+
+	it("存在しないホールで空配列を返す", () => {
+		expect(getHoleHazards("mock-course-001", 999)).toEqual([]);
+	});
+
+	it("存在しないコースで空配列を返す", () => {
+		expect(getHoleHazards("nonexistent", 1)).toEqual([]);
+	});
+});

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -1,0 +1,84 @@
+/**
+ * コースデータ管理
+ *
+ * MVP ではモックデータを使用する。
+ * Phase 1 で PostGIS + API から取得に切り替え予定。
+ */
+
+import type { Course, Hole } from "../types/course";
+
+/** モックコース: サンプルパー4ホール */
+const MOCK_HOLE_1: Hole = {
+	number: 1,
+	par: 4,
+	distanceYards: 370,
+	teePosition: { lat: 75, lng: 0 },
+	pinPosition: { lat: 75, lng: 370 },
+	fairwayCenter: { lat: 75, lng: 185 },
+	hazards: [
+		{
+			id: "h-bunker-1",
+			type: "bunker",
+			position: { lat: 120, lng: 200 },
+			radiusYards: 15,
+		},
+		{
+			id: "h-water-1",
+			type: "water",
+			position: { lat: 30, lng: 280 },
+			radiusYards: 20,
+		},
+	],
+};
+
+/** モックコース定義 */
+const MOCK_COURSE: Course = {
+	id: "mock-course-001",
+	name: "サンプルゴルフコース",
+	holes: [MOCK_HOLE_1],
+};
+
+/** 利用可能なコース一覧 */
+const COURSES: ReadonlyMap<string, Course> = new Map([[MOCK_COURSE.id, MOCK_COURSE]]);
+
+/** コースIDからコースを取得する */
+export function getCourseById(courseId: string): Course | undefined {
+	return COURSES.get(courseId);
+}
+
+/** 利用可能なコース一覧を返す */
+export function listCourses(): readonly Course[] {
+	return [...COURSES.values()];
+}
+
+/** コースの特定ホールからピン位置を取得する */
+export function getPinPosition(courseId: string, holeNumber: number): { lat: number; lng: number } | undefined {
+	const course = COURSES.get(courseId);
+	if (!course) return undefined;
+	const hole = course.holes.find((h) => h.number === holeNumber);
+	return hole?.pinPosition;
+}
+
+/** コースの特定ホールからティー位置を取得する */
+export function getTeePosition(courseId: string, holeNumber: number): { lat: number; lng: number } | undefined {
+	const course = COURSES.get(courseId);
+	if (!course) return undefined;
+	const hole = course.holes.find((h) => h.number === holeNumber);
+	return hole?.teePosition;
+}
+
+/** コースの特定ホールからハザード一覧を取得する */
+export function getHoleHazards(
+	courseId: string,
+	holeNumber: number,
+): readonly {
+	id: string;
+	type: string;
+	position: { lat: number; lng: number };
+	radiusYards: number;
+}[] {
+	const course = COURSES.get(courseId);
+	if (!course) return [];
+	const hole = course.holes.find((h) => h.number === holeNumber);
+	return hole?.hazards ?? [];
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,42 +1,78 @@
-import { StrictMode, useMemo, useState } from "react";
+import { StrictMode, useCallback, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ClubComparison } from "./components/ClubComparison";
 import { ClubSelector } from "./components/ClubSelector";
 import { CourseMap } from "./components/CourseMap";
 import { DistanceDistribution } from "./components/DistanceDistribution";
 import { Recommendation } from "./components/Recommendation";
+import { RoundSummary } from "./components/RoundSummary";
 import { ShotList } from "./components/ShotList";
 import { ShotScatter } from "./components/ShotScatter";
 import { StatsPanel } from "./components/StatsPanel";
 import { useRound } from "./hooks/useRound";
+import { getCourseById, listCourses } from "./lib/courses";
 import { RuleBasedEngine } from "./lib/recommendation";
 import { calculateClubStats, groupDistancesByClub } from "./lib/statistics";
+import type { Hazard } from "./types/course";
 
 const recommendationEngine = new RuleBasedEngine();
 
+/** デフォルトのコースID */
+const DEFAULT_COURSE_ID = "mock-course-001";
+
 function App() {
-	const { round, selectedClub, selectClub, recordShot, undoLastShot, startRound } = useRound();
+	const { round, selectedClub, selectClub, recordShot, undoLastShot, startRound, endRound } = useRound();
 	const [error, setError] = useState<string | null>(null);
 	const [showStats, setShowStats] = useState(false);
+	const [isRoundEnded, setIsRoundEnded] = useState(false);
+	const [selectedCourseId, setSelectedCourseId] = useState(DEFAULT_COURSE_ID);
 
-	const handleStartRound = () => {
-		startRound("mock-course-001");
+	const courses = useMemo(() => listCourses(), []);
+	const currentCourse = useMemo(() => getCourseById(selectedCourseId), [selectedCourseId]);
+
+	/** 現在のホール番号 (MVPでは常にホール1) */
+	const currentHoleNumber = 1;
+
+	/** 現在のホール情報 */
+	const currentHole = useMemo(() => {
+		if (!currentCourse) return undefined;
+		return currentCourse.holes.find((h) => h.number === currentHoleNumber);
+	}, [currentCourse]);
+
+	const handleStartRound = useCallback(() => {
+		startRound(selectedCourseId);
 		setError(null);
-	};
+		setIsRoundEnded(false);
+		setShowStats(false);
+	}, [startRound, selectedCourseId]);
+
+	const handleEndRound = useCallback(() => {
+		if (!round) return;
+		endRound(round.shots.length);
+		setIsRoundEnded(true);
+	}, [round, endRound]);
+
+	const handleNewRound = useCallback(() => {
+		setIsRoundEnded(false);
+		setShowStats(false);
+		setError(null);
+		startRound(selectedCourseId);
+	}, [startRound, selectedCourseId]);
 
 	const stats = useMemo(() => (round ? calculateClubStats(round.shots) : []), [round]);
 
 	const distancesByClub = useMemo(() => (round ? groupDistancesByClub(round.shots) : new Map()), [round]);
 
-	// クラブ推薦: ターゲットはモックコースのピン位置 (lat: 75, lng: 370)
+	// クラブ推薦: ターゲット位置をコースデータから動的に取得
 	const recommendations = useMemo(() => {
-		if (!round || round.shots.length === 0) return [];
+		if (!round || round.shots.length === 0 || !currentHole) return [];
 		const lastShot = round.shots[round.shots.length - 1];
 		if (!lastShot) return [];
 		const currentPos = lastShot.landingPosition;
-		const targetPos = { lat: 75, lng: 370 }; // モックコースのピン位置
-		return recommendationEngine.recommend(currentPos, targetPos, [], round.shots, 0);
-	}, [round]);
+		const targetPos = currentHole.pinPosition;
+		const hazards: readonly Hazard[] = currentHole.hazards;
+		return recommendationEngine.recommend(currentPos, targetPos, hazards, round.shots, 0);
+	}, [round, currentHole]);
 
 	return (
 		<StrictMode>
@@ -47,23 +83,96 @@ function App() {
 				</p>
 
 				{!round ? (
-					<button
-						type="button"
-						onClick={handleStartRound}
-						style={{
-							padding: "12px 24px",
-							fontSize: "16px",
-							backgroundColor: "#2563eb",
-							color: "#ffffff",
-							border: "none",
-							borderRadius: "8px",
-							cursor: "pointer",
-						}}
-					>
-						ラウンドを開始
-					</button>
+					<div>
+						{/* コース選択 */}
+						<div style={{ marginBottom: "16px" }}>
+							<label
+								htmlFor="course-select"
+								style={{
+									display: "block",
+									fontSize: "14px",
+									color: "#374151",
+									marginBottom: "4px",
+								}}
+							>
+								コースを選択:
+							</label>
+							<select
+								id="course-select"
+								value={selectedCourseId}
+								onChange={(e) => setSelectedCourseId(e.target.value)}
+								style={{
+									padding: "8px 12px",
+									fontSize: "14px",
+									border: "1px solid #d1d5db",
+									borderRadius: "6px",
+									width: "100%",
+									maxWidth: "400px",
+								}}
+							>
+								{courses.map((c) => (
+									<option key={c.id} value={c.id}>
+										{c.name}
+									</option>
+								))}
+							</select>
+						</div>
+						<button
+							type="button"
+							onClick={handleStartRound}
+							style={{
+								padding: "12px 24px",
+								fontSize: "16px",
+								backgroundColor: "#2563eb",
+								color: "#ffffff",
+								border: "none",
+								borderRadius: "8px",
+								cursor: "pointer",
+							}}
+						>
+							ラウンドを開始
+						</button>
+					</div>
+				) : isRoundEnded ? (
+					<RoundSummary round={round} courseName={currentCourse?.name ?? "不明なコース"} onNewRound={handleNewRound} />
 				) : (
 					<>
+						{/* コース情報ヘッダー */}
+						{currentHole && (
+							<div
+								style={{
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									padding: "8px 12px",
+									backgroundColor: "#f9fafb",
+									borderRadius: "6px",
+									marginBottom: "12px",
+									fontSize: "14px",
+								}}
+							>
+								<span>
+									{currentCourse?.name} - Hole {currentHole.number} (Par {currentHole.par}, {currentHole.distanceYards}
+									yd)
+								</span>
+								<button
+									type="button"
+									onClick={handleEndRound}
+									style={{
+										padding: "6px 14px",
+										fontSize: "13px",
+										backgroundColor: "#dc2626",
+										color: "#ffffff",
+										border: "none",
+										borderRadius: "6px",
+										cursor: "pointer",
+									}}
+								>
+									ラウンド終了
+								</button>
+							</div>
+						)}
+
 						<CourseMap
 							shots={round.shots}
 							onTap={(position) => {


### PR DESCRIPTION
## Summary
- Replaced hardcoded target coordinates `{ lat: 75, lng: 370 }` with dynamic lookup from structured course data
- Added round-end flow: "Round End" button -> RoundSummary screen with score card, club stats table, and "New Round" button
- Added course selection dropdown before round start

## Changes
- `src/lib/courses.ts`: new module with Course/Hole data and typed accessors (`getCourseById`, `getPinPosition`, `getHoleHazards`, etc.)
- `src/lib/courses.test.ts`: 11 unit tests for course data accessors
- `src/components/RoundSummary.tsx`: new component showing total shots, clubs used, avg distance, longest shot, club-by-club stats table
- `src/main.tsx`: course selection UI, dynamic target from `currentHole.pinPosition`, hazards passed to recommendation engine, round-end/new-round flow

## Test plan
- [x] `make check` passes (82 tests, format, lint, typecheck, build)
- [x] No hardcoded coordinates remain in `main.tsx`
- [x] Recommendation engine now receives hole hazards (previously empty array)
- [x] No `any` types, no `!!` assertions