### PR TITLE
fix: 座標系をヤード空間に統一しHaversine距離計算をユークリッドに変更

### DIFF
--- a/src/hooks/useRound.ts
+++ b/src/hooks/useRound.ts
@@ -10,25 +10,10 @@ import { LocalStorageAdapter } from "../lib/storage";
 import type { ClubType } from "../types/club";
 import type { Round } from "../types/round";
 import type { Coordinate, Shot } from "../types/shot";
-import { validateCoordinate, validateDistance } from "../types/shot";
+import { euclideanDistanceYards, validateCoordinate, validateDistance } from "../types/shot";
 
 const storage = new LocalStorageAdapter();
 const ROUNDS_KEY = "rounds";
-
-/** 座標間の距離をヤードで計算 (Haversine formula) */
-function calculateDistanceYards(from: Coordinate, to: Coordinate): number {
-	const R = 6371000; // 地球の半径 (メートル)
-	const toRad = (deg: number) => (deg * Math.PI) / 180;
-
-	const dLat = toRad(to.lat - from.lat);
-	const dLng = toRad(to.lng - from.lng);
-	const a =
-		Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-		Math.cos(toRad(from.lat)) * Math.cos(toRad(to.lat)) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
-	const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-	const meters = R * c;
-	return meters * 1.09361; // メートル → ヤード
-}
 
 /** ユニークIDを生成 */
 function generateId(): string {
@@ -80,8 +65,8 @@ export function useRound(): UseRoundReturn {
 
 			const shotNumber = round.shots.filter((s) => s.holeNumber === currentHole).length + 1;
 
-			// 飛距離: 前のショットの着弾位置から計算、なければ0
-			const distanceYards = lastShotPosition ? calculateDistanceYards(lastShotPosition, position) : 0;
+			// 飛距離: 前のショットの着弾位置からユークリッド距離で計算、なければ0
+			const distanceYards = lastShotPosition ? euclideanDistanceYards(lastShotPosition, position) : 0;
 
 			const distanceError = validateDistance(distanceYards);
 			if (distanceError) return distanceError;

--- a/src/lib/recommendation.test.ts
+++ b/src/lib/recommendation.test.ts
@@ -10,8 +10,8 @@ function createShot(overrides: Partial<Shot> & Pick<Shot, "club" | "distanceYard
 		roundId: "round-1",
 		holeNumber: 1,
 		shotNumber: 1,
-		position: { lat: 35.0, lng: 139.0 },
-		landingPosition: { lat: 35.001, lng: 139.001 },
+		position: { lat: 75, lng: 0 },
+		landingPosition: { lat: 75, lng: 140 },
 		timestamp: "2026-01-01T00:00:00Z",
 		...overrides,
 	};
@@ -20,9 +20,9 @@ function createShot(overrides: Partial<Shot> & Pick<Shot, "club" | "distanceYard
 describe("RuleBasedEngine", () => {
 	const engine = new RuleBasedEngine();
 
-	const teePosition: Coordinate = { lat: 35.0, lng: 139.0 };
-	// ターゲットはティーから約230ヤード先 (ドライバー距離)
-	const targetPosition: Coordinate = { lat: 35.0019, lng: 139.0 };
+	// ヤード座標系: ティー位置 (75, 0), ターゲット (75, 230) → 距離230yd
+	const teePosition: Coordinate = { lat: 75, lng: 0 };
+	const targetPosition: Coordinate = { lat: 75, lng: 230 };
 
 	describe("コールドスタート (ジェネリック推薦)", () => {
 		it("5ラウンド未満ではジェネリック推薦を返す", () => {
@@ -73,8 +73,8 @@ describe("RuleBasedEngine", () => {
 				createShot({ id: "s4", club: "7i", distanceYards: 142 }),
 				createShot({ id: "s5", club: "7i", distanceYards: 138 }),
 			];
-			// ターゲットを7I距離(≈140yd)に設定
-			const shortTarget: Coordinate = { lat: 35.00117, lng: 139.0 };
+			// ターゲットを7I距離(=140yd)に設定
+			const shortTarget: Coordinate = { lat: 75, lng: 140 };
 			const recommendations = engine.recommend(teePosition, shortTarget, [], shots, 5);
 			const sevenIron = recommendations.find((r) => r.club === "7i");
 			if (sevenIron) {
@@ -101,19 +101,28 @@ describe("RuleBasedEngine", () => {
 			}
 		});
 
-		it("ハザードがある場合はリスクが正の値", () => {
+		it("ハザードがある場合はリスクが期待値を下げる", () => {
+			// ハザードをドライバー平均飛距離(230yd)付近に配置
 			const hazards: Hazard[] = [
 				{
 					id: "h1",
 					type: "water",
-					position: { lat: 35.0015, lng: 139.0 },
-					radiusYards: 20,
+					position: { lat: 75, lng: 230 },
+					radiusYards: 30,
 				},
 			];
-			const recommendations = engine.recommend(teePosition, targetPosition, hazards, [], 0);
-			// 少なくとも1つのクラブがハザードリスクを持つ
-			const hasRisk = recommendations.some((r) => r.hazardRisk > 0);
-			expect(hasRisk).toBe(true);
+			const withHazards = engine.recommend(teePosition, targetPosition, hazards, [], 0);
+			const withoutHazards = engine.recommend(teePosition, targetPosition, [], [], 0);
+
+			// ハザードありの方が上位クラブの期待値が低い（上位がリスク回避クラブに入替わる）
+			const topWithHazards = withHazards[0];
+			const topWithoutHazards = withoutHazards[0];
+			expect(topWithHazards).toBeDefined();
+			expect(topWithoutHazards).toBeDefined();
+			if (topWithHazards && topWithoutHazards) {
+				// ハザードありではドライバーが推薦されなくなり、異なるクラブが選ばれる
+				expect(topWithHazards.club).not.toBe(topWithoutHazards.club);
+			}
 		});
 
 		it("ハザードリスクが期待値を下げる", () => {
@@ -122,7 +131,7 @@ describe("RuleBasedEngine", () => {
 				{
 					id: "h1",
 					type: "water",
-					position: { lat: 35.0015, lng: 139.0 },
+					position: { lat: 75, lng: 200 },
 					radiusYards: 30,
 				},
 			];
@@ -142,7 +151,7 @@ describe("RuleBasedEngine", () => {
 				{
 					id: "h1",
 					type: "water",
-					position: { lat: 35.0015, lng: 139.0 },
+					position: { lat: 75, lng: 200 },
 					radiusYards: 20,
 				},
 			];
@@ -150,7 +159,7 @@ describe("RuleBasedEngine", () => {
 				{
 					id: "h1",
 					type: "ob",
-					position: { lat: 35.0015, lng: 139.0 },
+					position: { lat: 75, lng: 200 },
 					radiusYards: 20,
 				},
 			];
@@ -177,7 +186,7 @@ describe("RuleBasedEngine", () => {
 		});
 
 		it("平均飛距離がターゲットに近いクラブほどフェアウェイキープ率が高い", () => {
-			// ターゲット ≈ 230yd → ドライバー(mean=230)が最もキープ率が高いはず
+			// ターゲット = 230yd → ドライバー(mean=230)が最もキープ率が高いはず
 			const allRecs = engine.recommend(teePosition, targetPosition, [], [], 0);
 			const topRec = allRecs[0];
 			expect(topRec).toBeDefined();
@@ -215,7 +224,7 @@ describe("RuleBasedEngine", () => {
 			const hazards: Hazard[] = Array.from({ length: 50 }, (_, i) => ({
 				id: `h${i}`,
 				type: "bunker" as const,
-				position: { lat: 35.0 + i * 0.0001, lng: 139.0 },
+				position: { lat: 75, lng: i * 8 },
 				radiusYards: 10,
 			}));
 			const recommendations = engine.recommend(teePosition, targetPosition, hazards, [], 0);

--- a/src/lib/recommendation.ts
+++ b/src/lib/recommendation.ts
@@ -10,6 +10,7 @@
 import type { ClubType } from "../types/club";
 import type { Hazard } from "../types/course";
 import type { Coordinate, Shot } from "../types/shot";
+import { euclideanDistanceYards } from "../types/shot";
 import { mean, normalCdf, stdDev } from "./statistics";
 
 /** ハザード種別ごとのペナルティコスト */
@@ -40,19 +41,6 @@ const GENERIC_STATS: ReadonlyMap<ClubType, { mean: number; stdDev: number }> = n
 	["lw", { mean: 60, stdDev: 5 }],
 	["putter", { mean: 10, stdDev: 3 }],
 ]);
-
-/** 2点間の距離 (ヤード, Haversine) */
-function distanceYards(from: Coordinate, to: Coordinate): number {
-	const R = 6371000;
-	const toRad = (deg: number) => (deg * Math.PI) / 180;
-	const dLat = toRad(to.lat - from.lat);
-	const dLng = toRad(to.lng - from.lng);
-	const a =
-		Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-		Math.cos(toRad(from.lat)) * Math.cos(toRad(to.lat)) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
-	const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-	return R * c * 1.09361;
-}
 
 /** 推薦結果 */
 export interface ClubRecommendation {
@@ -92,7 +80,7 @@ function calculateFairwayRate(targetDistance: number, clubMean: number, clubStdD
 	return upper - lower;
 }
 
-/** ハザード到達確率を計算 */
+/** ハザード到達確率を計算 (ユークリッド距離) */
 function calculateHazardRisk(
 	currentPosition: Coordinate,
 	hazards: readonly Hazard[],
@@ -104,7 +92,7 @@ function calculateHazardRisk(
 
 	let totalRisk = 0;
 	for (const hazard of hazards) {
-		const hazardDistance = distanceYards(currentPosition, hazard.position);
+		const hazardDistance = euclideanDistanceYards(currentPosition, hazard.position);
 		const hazardNear = hazardDistance - hazard.radiusYards;
 		const hazardFar = hazardDistance + hazard.radiusYards;
 
@@ -133,7 +121,7 @@ export class RuleBasedEngine implements RecommendationEngine {
 		shots: readonly Shot[],
 		roundCount: number,
 	): readonly ClubRecommendation[] {
-		const targetDistance = distanceYards(currentPosition, targetPosition);
+		const targetDistance = euclideanDistanceYards(currentPosition, targetPosition);
 		const isGeneric = roundCount < this.coldStartThreshold;
 		const tolerance = 15; // ターゲットからの許容誤差 (ヤード)
 

--- a/src/types/shot.ts
+++ b/src/types/shot.ts
@@ -1,10 +1,10 @@
 import type { ClubType } from "./club";
 
-/** WGS84 座標 (EPSG:4326) */
+/** コースマップ上のヤード座標 (横方向: lng, 縦方向: lat) */
 export interface Coordinate {
-	/** 緯度 (-90.0 ~ 90.0) */
+	/** 縦位置 (ヤード, 0 ~ 150) */
 	readonly lat: number;
-	/** 経度 (-180.0 ~ 180.0) */
+	/** 横位置 (ヤード, 0 ~ 400) */
 	readonly lng: number;
 }
 
@@ -22,15 +22,22 @@ export interface Shot {
 	readonly timestamp: string;
 }
 
-/** 座標バリデーション */
+/** 座標バリデーション (ヤード座標系) */
 export function validateCoordinate(coord: Coordinate): string | null {
-	if (coord.lat < -90 || coord.lat > 90) {
-		return "緯度は-90~90の範囲で指定してください";
+	if (coord.lat < 0 || coord.lat > 150) {
+		return "縦位置は0~150ヤードの範囲で指定してください";
 	}
-	if (coord.lng < -180 || coord.lng > 180) {
-		return "経度は-180~180の範囲で指定してください";
+	if (coord.lng < 0 || coord.lng > 400) {
+		return "横位置は0~400ヤードの範囲で指定してください";
 	}
 	return null;
+}
+
+/** 2点間のユークリッド距離 (ヤード) */
+export function euclideanDistanceYards(from: Coordinate, to: Coordinate): number {
+	const dx = to.lng - from.lng;
+	const dy = to.lat - from.lat;
+	return Math.sqrt(dx * dx + dy * dy);
 }
 
 /** 飛距離バリデーション */

--- a/src/types/validation.test.ts
+++ b/src/types/validation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { isClubType, validateClubName } from "./club";
 import { isHazardType } from "./course";
 import { validateRoundDate } from "./round";
-import { validateCoordinate, validateDistance } from "./shot";
+import { euclideanDistanceYards, validateCoordinate, validateDistance } from "./shot";
 
 describe("validateClubName", () => {
 	it("正常なクラブ名はnullを返す", () => {
@@ -40,24 +40,45 @@ describe("isClubType", () => {
 	});
 });
 
-describe("validateCoordinate", () => {
-	it("有効な座標はnullを返す", () => {
-		expect(validateCoordinate({ lat: 35.6812, lng: 139.7671 })).toBeNull();
+describe("validateCoordinate (ヤード座標系)", () => {
+	it("有効なヤード座標はnullを返す", () => {
+		expect(validateCoordinate({ lat: 75, lng: 200 })).toBeNull();
 	});
 
-	it("緯度が範囲外の場合はエラーを返す", () => {
-		expect(validateCoordinate({ lat: 91, lng: 0 })).not.toBeNull();
-		expect(validateCoordinate({ lat: -91, lng: 0 })).not.toBeNull();
+	it("縦位置が範囲外の場合はエラーを返す", () => {
+		expect(validateCoordinate({ lat: 151, lng: 0 })).not.toBeNull();
+		expect(validateCoordinate({ lat: -1, lng: 0 })).not.toBeNull();
 	});
 
-	it("経度が範囲外の場合はエラーを返す", () => {
-		expect(validateCoordinate({ lat: 0, lng: 181 })).not.toBeNull();
-		expect(validateCoordinate({ lat: 0, lng: -181 })).not.toBeNull();
+	it("横位置が範囲外の場合はエラーを返す", () => {
+		expect(validateCoordinate({ lat: 0, lng: 401 })).not.toBeNull();
+		expect(validateCoordinate({ lat: 0, lng: -1 })).not.toBeNull();
 	});
 
 	it("境界値はnullを返す", () => {
-		expect(validateCoordinate({ lat: 90, lng: 180 })).toBeNull();
-		expect(validateCoordinate({ lat: -90, lng: -180 })).toBeNull();
+		expect(validateCoordinate({ lat: 150, lng: 400 })).toBeNull();
+		expect(validateCoordinate({ lat: 0, lng: 0 })).toBeNull();
+	});
+});
+
+describe("euclideanDistanceYards", () => {
+	it("同一地点の距離は0", () => {
+		expect(euclideanDistanceYards({ lat: 75, lng: 0 }, { lat: 75, lng: 0 })).toBe(0);
+	});
+
+	it("水平方向の距離を正しく計算する", () => {
+		const d = euclideanDistanceYards({ lat: 75, lng: 0 }, { lat: 75, lng: 200 });
+		expect(d).toBeCloseTo(200, 5);
+	});
+
+	it("垂直方向の距離を正しく計算する", () => {
+		const d = euclideanDistanceYards({ lat: 0, lng: 100 }, { lat: 100, lng: 100 });
+		expect(d).toBeCloseTo(100, 5);
+	});
+
+	it("斜め方向の距離をピタゴラスの定理で計算する", () => {
+		const d = euclideanDistanceYards({ lat: 0, lng: 0 }, { lat: 30, lng: 40 });
+		expect(d).toBeCloseTo(50, 5);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Coordinate定義をWGS84からヤード座標系に変更 (CourseMapの0-400x0-150空間に整合)
- useRound.ts / recommendation.ts のHaversine距離計算をeuclideanDistanceYardsに置換
- validateCoordinateのバリデーション範囲をヤード座標に修正 (lat: 0-150, lng: 0-400)
- テストの座標値をヤード座標系に統一

## Test plan
- [x] euclideanDistanceYards の単体テスト追加 (水平/垂直/斜め/同一地点)
- [x] validateCoordinate のヤード座標系テスト追加
- [x] recommendation テストの座標をヤード座標系に修正
- [x] make check (format + lint + typecheck + test + build) 全パス