### PR TITLE
feat: Go REST APIバックエンド実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ test-results/
 playwright-report/
 blob-report/
 
+# Go
+api/bin/
+api/tmp/
+
 # Misc
 *.log
 *.tgz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,29 @@
 
 ## 技術スタック
 - TypeScript / React + D3.js（フロントエンド）
-- Go（API層、gRPC）
-- Python（ML / 統計モデル）
-- PostgreSQL + PostGIS
+- Go（REST API、標準ライブラリのみ）
+- Python（ML / 統計モデル、Phase 2）
+- PostgreSQL + PostGIS（Phase 2、MVP はインメモリ）
 - GCP Cloud Run
 
 ## ルール
 - TypeScript: ~/.claude/rules/typescript.md 参照
+- Go: ~/.claude/rules/go.md 参照
 - Proto: ~/.claude/rules/proto.md 参照
 
 ## コマンド
 ```
-make check     # format → lint → typecheck → test → build
-make quality   # 品質ゲート
-make test-e2e  # Playwright E2E テスト
+make check      # FE + Go API 全チェック
+make api-test   # Go API テスト
+make api-run    # Go API サーバー起動 (port 8080)
+make quality    # 品質ゲート
+make test-e2e   # Playwright E2E テスト
 ```
 
 ## ディレクトリ構造
 ```
 src/           # React コンポーネント・hooks・lib・types
+api/           # Go API (cmd/server, internal/{handler,model,service,store,middleware})
 public/        # 静的アセット
 test/e2e/      # Playwright E2E テスト
 docs/          # 品質チェックリスト等

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint format typecheck check clean install deps-check test-e2e quality
+.PHONY: build test lint format typecheck check clean install deps-check test-e2e quality api-build api-test api-run api-check
 
 install:
 	npm install
@@ -19,11 +19,24 @@ format:
 typecheck:
 	npx tsc --noEmit
 
-check: format lint typecheck test build
+check: format lint typecheck test build api-check
 	@echo "All checks passed."
 
 test-e2e:
 	npx playwright test
+
+# Go API
+api-build:
+	cd api && go build ./...
+
+api-test:
+	cd api && go test -race -count=1 ./...
+
+api-run:
+	cd api && go run ./cmd/server
+
+api-check: api-build api-test
+	@echo "Go API checks passed."
 
 quality:
 	@echo "=== Quality Gate ==="

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ryusei/fairway-caddie/api/internal/handler"
+	"github.com/ryusei/fairway-caddie/api/internal/middleware"
+	"github.com/ryusei/fairway-caddie/api/internal/service"
+	"github.com/ryusei/fairway-caddie/api/internal/store"
+)
+
+func main() {
+	port := os.Getenv("API_PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	// ストア初期化
+	shotStore := store.NewMemoryShotStore()
+	roundStore := store.NewMemoryRoundStore()
+	courseStore := store.NewMemoryCourseStore()
+
+	// サービス初期化
+	recommendService := service.NewRecommendationService(5)
+
+	// ハンドラ初期化
+	shotHandler := handler.NewShotHandler(shotStore)
+	roundHandler := handler.NewRoundHandler(roundStore)
+	courseHandler := handler.NewCourseHandler(courseStore)
+	statsHandler := handler.NewStatsHandler(shotStore)
+	recommendHandler := handler.NewRecommendationHandler(recommendService)
+
+	// ルーティング
+	mux := http.NewServeMux()
+
+	// ヘルスチェック
+	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"error":"メソッドが許可されていません"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+			log.Printf("ヘルスチェックレスポンスの書き込みに失敗: %v", err)
+		}
+	})
+
+	// ショットAPI
+	mux.HandleFunc("/api/shots", shotHandler.HandleShots)
+	mux.HandleFunc("/api/shots/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/api/shots/")
+		if path == "" || strings.Contains(path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		shotHandler.HandleShotByID(w, r)
+	})
+
+	// ラウンドAPI
+	mux.HandleFunc("/api/rounds", roundHandler.HandleRounds)
+	mux.HandleFunc("/api/rounds/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/api/rounds/")
+		if path == "" || strings.Contains(path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		roundHandler.HandleRoundByID(w, r)
+	})
+
+	// コースAPI
+	mux.HandleFunc("/api/courses", courseHandler.HandleCourses)
+	mux.HandleFunc("/api/courses/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/api/courses/")
+		if path == "" || strings.Contains(path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		courseHandler.HandleCourseByID(w, r)
+	})
+
+	// 統計API
+	mux.HandleFunc("/api/stats", statsHandler.HandleStats)
+
+	// 推薦API
+	mux.HandleFunc("/api/recommend", recommendHandler.HandleRecommend)
+
+	// ミドルウェア適用
+	var h http.Handler = mux
+	h = middleware.CORS(h)
+	h = middleware.Logging(h)
+
+	server := &http.Server{
+		Addr:              ":" + port,
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	// Graceful shutdown
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		log.Printf("fairway-caddie API server starting on :%s", port)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("サーバーの起動に失敗しました: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	log.Println("シャットダウンシグナルを受信しました...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("サーバーのシャットダウンに失敗しました: %v", err)
+	}
+	log.Println("サーバーを正常にシャットダウンしました")
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,0 +1,3 @@
+module github.com/ryusei/fairway-caddie/api
+
+go 1.25.0

--- a/api/internal/handler/course.go
+++ b/api/internal/handler/course.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/ryusei/fairway-caddie/api/internal/store"
+)
+
+// CourseHandler はコースAPIのハンドラ。
+type CourseHandler struct {
+	store store.CourseStore
+}
+
+// NewCourseHandler は新しいCourseHandlerを作成する。
+func NewCourseHandler(s store.CourseStore) *CourseHandler {
+	return &CourseHandler{store: s}
+}
+
+// HandleCourses は /api/courses エンドポイントのハンドラ。
+func (h *CourseHandler) HandleCourses(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listCourses(w, r)
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+	}
+}
+
+// HandleCourseByID は /api/courses/{id} エンドポイントのハンドラ。
+func (h *CourseHandler) HandleCourseByID(w http.ResponseWriter, r *http.Request) {
+	id := extractIDFromPath(r.URL.Path, "/api/courses/")
+	if id == "" {
+		respondError(w, http.StatusBadRequest, "コースIDが指定されていません")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getCourse(w, r, id)
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+	}
+}
+
+func (h *CourseHandler) listCourses(w http.ResponseWriter, r *http.Request) {
+	courses, err := h.store.List(r.Context())
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "コースの取得に失敗しました")
+		return
+	}
+	respondJSON(w, http.StatusOK, courses)
+}
+
+func (h *CourseHandler) getCourse(w http.ResponseWriter, r *http.Request, id string) {
+	course, err := h.store.GetByID(r.Context(), id)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "コースが見つかりません")
+		return
+	}
+	respondJSON(w, http.StatusOK, course)
+}

--- a/api/internal/handler/handler_test.go
+++ b/api/internal/handler/handler_test.go
@@ -1,0 +1,410 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/handler"
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/service"
+	"github.com/ryusei/fairway-caddie/api/internal/store"
+)
+
+func setupShotHandler() (*handler.ShotHandler, *store.MemoryShotStore) {
+	s := store.NewMemoryShotStore()
+	h := handler.NewShotHandler(s)
+	return h, s
+}
+
+func setupRoundHandler() (*handler.RoundHandler, *store.MemoryRoundStore) {
+	s := store.NewMemoryRoundStore()
+	h := handler.NewRoundHandler(s)
+	return h, s
+}
+
+func validShot() model.Shot {
+	return model.Shot{
+		ID:              "shot-1",
+		RoundID:         "round-1",
+		HoleNumber:      1,
+		ShotNumber:      1,
+		Club:            model.ClubDriver,
+		Position:        model.Coordinate{Lat: 75, Lng: 0},
+		LandingPosition: model.Coordinate{Lat: 75, Lng: 230},
+		DistanceYards:   230,
+		Timestamp:       "2026-01-01T00:00:00Z",
+	}
+}
+
+func validRound() model.Round {
+	return model.Round{
+		ID:       "round-1",
+		CourseID: "mock-course-001",
+		Date:     "2025-06-01",
+		Shots:    []model.Shot{},
+	}
+}
+
+func TestShotHandler_CreateAndList(t *testing.T) {
+	h, _ := setupShotHandler()
+
+	// POST /api/shots
+	body, marshalErr := json.Marshal(validShot())
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/shots", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleShots(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("POST /api/shots status = %d, want %d", w.Code, http.StatusCreated)
+	}
+
+	// GET /api/shots
+	req = httptest.NewRequest(http.MethodGet, "/api/shots", nil)
+	w = httptest.NewRecorder()
+	h.HandleShots(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/shots status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var shots []model.Shot
+	if err := json.NewDecoder(w.Body).Decode(&shots); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(shots) != 1 {
+		t.Errorf("expected 1 shot, got %d", len(shots))
+	}
+}
+
+func TestShotHandler_GetByID(t *testing.T) {
+	h, s := setupShotHandler()
+	if _, err := s.Create(nil, validShot()); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/shots/shot-1", nil)
+	w := httptest.NewRecorder()
+	h.HandleShotByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/shots/shot-1 status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestShotHandler_GetByID_NotFound(t *testing.T) {
+	h, _ := setupShotHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/shots/nonexistent", nil)
+	w := httptest.NewRecorder()
+	h.HandleShotByID(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /api/shots/nonexistent status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestShotHandler_Update(t *testing.T) {
+	h, s := setupShotHandler()
+	if _, err := s.Create(nil, validShot()); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	updated := validShot()
+	updated.DistanceYards = 250
+	body, marshalErr := json.Marshal(updated)
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/shots/shot-1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleShotByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("PUT /api/shots/shot-1 status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestShotHandler_Delete(t *testing.T) {
+	h, s := setupShotHandler()
+	if _, err := s.Create(nil, validShot()); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/shots/shot-1", nil)
+	w := httptest.NewRecorder()
+	h.HandleShotByID(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("DELETE /api/shots/shot-1 status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestShotHandler_InvalidMethod(t *testing.T) {
+	h, _ := setupShotHandler()
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/shots", nil)
+	w := httptest.NewRecorder()
+	h.HandleShots(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("PATCH /api/shots status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestShotHandler_InvalidBody(t *testing.T) {
+	h, _ := setupShotHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/shots", bytes.NewReader([]byte("invalid")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleShots(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/shots with invalid body status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestShotHandler_ValidationError(t *testing.T) {
+	h, _ := setupShotHandler()
+
+	shot := validShot()
+	shot.Club = "invalid"
+	body, marshalErr := json.Marshal(shot)
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/shots", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleShots(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/shots with invalid club status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestShotHandler_ListByRound(t *testing.T) {
+	h, s := setupShotHandler()
+
+	shot1 := validShot()
+	shot2 := validShot()
+	shot2.ID = "shot-2"
+	shot2.RoundID = "round-2"
+
+	if _, err := s.Create(nil, shot1); err != nil {
+		t.Fatalf("create shot1 error: %v", err)
+	}
+	if _, err := s.Create(nil, shot2); err != nil {
+		t.Fatalf("create shot2 error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/shots?roundId=round-1", nil)
+	w := httptest.NewRecorder()
+	h.HandleShots(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/shots?roundId=round-1 status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var shots []model.Shot
+	if err := json.NewDecoder(w.Body).Decode(&shots); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(shots) != 1 {
+		t.Errorf("expected 1 shot for round-1, got %d", len(shots))
+	}
+}
+
+func TestRoundHandler_CreateAndList(t *testing.T) {
+	h, _ := setupRoundHandler()
+
+	body, marshalErr := json.Marshal(validRound())
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/rounds", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleRounds(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("POST /api/rounds status = %d, want %d. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/rounds", nil)
+	w = httptest.NewRecorder()
+	h.HandleRounds(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/rounds status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var rounds []model.Round
+	if err := json.NewDecoder(w.Body).Decode(&rounds); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(rounds) != 1 {
+		t.Errorf("expected 1 round, got %d", len(rounds))
+	}
+}
+
+func TestCourseHandler_ListAndGet(t *testing.T) {
+	s := store.NewMemoryCourseStore()
+	h := handler.NewCourseHandler(s)
+
+	// GET /api/courses
+	req := httptest.NewRequest(http.MethodGet, "/api/courses", nil)
+	w := httptest.NewRecorder()
+	h.HandleCourses(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/courses status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var courses []model.Course
+	if err := json.NewDecoder(w.Body).Decode(&courses); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(courses) == 0 {
+		t.Error("expected at least 1 course")
+	}
+
+	// GET /api/courses/mock-course-001
+	req = httptest.NewRequest(http.MethodGet, "/api/courses/mock-course-001", nil)
+	w = httptest.NewRecorder()
+	h.HandleCourseByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/courses/mock-course-001 status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestStatsHandler(t *testing.T) {
+	shotStore := store.NewMemoryShotStore()
+	h := handler.NewStatsHandler(shotStore)
+
+	// 空の状態
+	req := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+	w := httptest.NewRecorder()
+	h.HandleStats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/stats status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// データ投入
+	shot := validShot()
+	if _, err := shotStore.Create(nil, shot); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+	w = httptest.NewRecorder()
+	h.HandleStats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/stats with data status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var stats []model.DistanceStats
+	if err := json.NewDecoder(w.Body).Decode(&stats); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Errorf("expected 1 stat, got %d", len(stats))
+	}
+
+	// Method not allowed
+	req = httptest.NewRequest(http.MethodPost, "/api/stats", nil)
+	w = httptest.NewRecorder()
+	h.HandleStats(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /api/stats status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestRecommendationHandler(t *testing.T) {
+	engine := service.NewRecommendationService(5)
+	h := handler.NewRecommendationHandler(engine)
+
+	reqBody := model.RecommendRequest{
+		CurrentPosition: model.Coordinate{Lat: 75, Lng: 0},
+		TargetPosition:  model.Coordinate{Lat: 75, Lng: 230},
+		Hazards:         []model.Hazard{},
+		Shots:           []model.Shot{},
+		RoundCount:      0,
+	}
+
+	body, marshalErr := json.Marshal(reqBody)
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+
+	t.Run("正常リクエスト", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/recommend", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleRecommend(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("POST /api/recommend status = %d, want %d. Body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		var recs []model.ClubRecommendation
+		if err := json.NewDecoder(w.Body).Decode(&recs); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+		if len(recs) != 3 {
+			t.Errorf("expected 3 recommendations, got %d", len(recs))
+		}
+	})
+
+	t.Run("不正なメソッド", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/recommend", nil)
+		w := httptest.NewRecorder()
+		h.HandleRecommend(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("GET /api/recommend status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+		}
+	})
+
+	t.Run("不正なボディ", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/recommend", bytes.NewReader([]byte("invalid")))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleRecommend(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("POST /api/recommend with invalid body status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("不正な座標", func(t *testing.T) {
+		invalidReq := model.RecommendRequest{
+			CurrentPosition: model.Coordinate{Lat: 999, Lng: 0},
+			TargetPosition:  model.Coordinate{Lat: 75, Lng: 230},
+		}
+		invalidBody, marshalErr := json.Marshal(invalidReq)
+		if marshalErr != nil {
+			t.Fatalf("marshal error: %v", marshalErr)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/recommend", bytes.NewReader(invalidBody))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleRecommend(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("POST /api/recommend with invalid coordinate status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+}

--- a/api/internal/handler/recommendation.go
+++ b/api/internal/handler/recommendation.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/service"
+)
+
+// RecommendationHandler はクラブ推薦APIのハンドラ。
+type RecommendationHandler struct {
+	engine *service.RecommendationService
+}
+
+// NewRecommendationHandler は新しいRecommendationHandlerを作成する。
+func NewRecommendationHandler(engine *service.RecommendationService) *RecommendationHandler {
+	return &RecommendationHandler{engine: engine}
+}
+
+// HandleRecommend は /api/recommend エンドポイントのハンドラ。
+func (h *RecommendationHandler) HandleRecommend(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+		return
+	}
+
+	var req model.RecommendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
+		return
+	}
+
+	if err := req.CurrentPosition.Validate(); err != nil {
+		respondError(w, http.StatusBadRequest, "現在位置が不正です: "+err.Error())
+		return
+	}
+	if err := req.TargetPosition.Validate(); err != nil {
+		respondError(w, http.StatusBadRequest, "ターゲット位置が不正です: "+err.Error())
+		return
+	}
+
+	if req.Hazards == nil {
+		req.Hazards = []model.Hazard{}
+	}
+	if req.Shots == nil {
+		req.Shots = []model.Shot{}
+	}
+
+	recommendations := h.engine.Recommend(
+		req.CurrentPosition,
+		req.TargetPosition,
+		req.Hazards,
+		req.Shots,
+		req.RoundCount,
+	)
+
+	respondJSON(w, http.StatusOK, recommendations)
+}

--- a/api/internal/handler/response.go
+++ b/api/internal/handler/response.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ErrorResponse はAPIエラーレスポンス。
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// respondJSON はJSONレスポンスを返す。
+func respondJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		http.Error(w, `{"error":"レスポンスのエンコードに失敗しました"}`, http.StatusInternalServerError)
+	}
+}
+
+// respondError はエラーレスポンスを返す。
+func respondError(w http.ResponseWriter, status int, message string) {
+	respondJSON(w, status, ErrorResponse{Error: message})
+}

--- a/api/internal/handler/round.go
+++ b/api/internal/handler/round.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/store"
+)
+
+// RoundHandler はラウンドAPIのハンドラ。
+type RoundHandler struct {
+	store store.RoundStore
+}
+
+// NewRoundHandler は新しいRoundHandlerを作成する。
+func NewRoundHandler(s store.RoundStore) *RoundHandler {
+	return &RoundHandler{store: s}
+}
+
+// HandleRounds は /api/rounds エンドポイントのハンドラ。
+func (h *RoundHandler) HandleRounds(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listRounds(w, r)
+	case http.MethodPost:
+		h.createRound(w, r)
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+	}
+}
+
+// HandleRoundByID は /api/rounds/{id} エンドポイントのハンドラ。
+func (h *RoundHandler) HandleRoundByID(w http.ResponseWriter, r *http.Request) {
+	id := extractIDFromPath(r.URL.Path, "/api/rounds/")
+	if id == "" {
+		respondError(w, http.StatusBadRequest, "ラウンドIDが指定されていません")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getRound(w, r, id)
+	case http.MethodPut:
+		h.updateRound(w, r, id)
+	case http.MethodDelete:
+		h.deleteRound(w, r, id)
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+	}
+}
+
+func (h *RoundHandler) listRounds(w http.ResponseWriter, r *http.Request) {
+	rounds, err := h.store.List(r.Context())
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ラウンドの取得に失敗しました")
+		return
+	}
+	if rounds == nil {
+		rounds = []model.Round{}
+	}
+	respondJSON(w, http.StatusOK, rounds)
+}
+
+func (h *RoundHandler) getRound(w http.ResponseWriter, r *http.Request, id string) {
+	round, err := h.store.GetByID(r.Context(), id)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "ラウンドが見つかりません")
+		return
+	}
+	respondJSON(w, http.StatusOK, round)
+}
+
+func (h *RoundHandler) createRound(w http.ResponseWriter, r *http.Request) {
+	var round model.Round
+	if err := json.NewDecoder(r.Body).Decode(&round); err != nil {
+		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
+		return
+	}
+
+	if err := round.Validate(); err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	created, err := h.store.Create(r.Context(), round)
+	if err != nil {
+		respondError(w, http.StatusConflict, err.Error())
+		return
+	}
+	respondJSON(w, http.StatusCreated, created)
+}
+
+func (h *RoundHandler) updateRound(w http.ResponseWriter, r *http.Request, id string) {
+	var round model.Round
+	if err := json.NewDecoder(r.Body).Decode(&round); err != nil {
+		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
+		return
+	}
+	round.ID = id
+
+	if err := round.Validate(); err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	updated, err := h.store.Update(r.Context(), round)
+	if err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	respondJSON(w, http.StatusOK, updated)
+}
+
+func (h *RoundHandler) deleteRound(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/api/internal/handler/shot.go
+++ b/api/internal/handler/shot.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/store"
+)
+
+// ShotHandler はショットAPIのハンドラ。
+type ShotHandler struct {
+	store store.ShotStore
+}
+
+// NewShotHandler は新しいShotHandlerを作成する。
+func NewShotHandler(s store.ShotStore) *ShotHandler {
+	return &ShotHandler{store: s}
+}
+
+// HandleShots は /api/shots エンドポイントのハンドラ。
+func (h *ShotHandler) HandleShots(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listShots(w, r)
+	case http.MethodPost:
+		h.createShot(w, r)
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+	}
+}
+
+// HandleShotByID は /api/shots/{id} エンドポイントのハンドラ。
+func (h *ShotHandler) HandleShotByID(w http.ResponseWriter, r *http.Request) {
+	id := extractIDFromPath(r.URL.Path, "/api/shots/")
+	if id == "" {
+		respondError(w, http.StatusBadRequest, "ショットIDが指定されていません")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getShot(w, r, id)
+	case http.MethodPut:
+		h.updateShot(w, r, id)
+	case http.MethodDelete:
+		h.deleteShot(w, r, id)
+	default:
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+	}
+}
+
+func (h *ShotHandler) listShots(w http.ResponseWriter, r *http.Request) {
+	roundID := r.URL.Query().Get("roundId")
+	var shots []model.Shot
+	var err error
+
+	if roundID != "" {
+		shots, err = h.store.ListByRound(r.Context(), roundID)
+	} else {
+		shots, err = h.store.List(r.Context())
+	}
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ショットの取得に失敗しました")
+		return
+	}
+
+	if shots == nil {
+		shots = []model.Shot{}
+	}
+	respondJSON(w, http.StatusOK, shots)
+}
+
+func (h *ShotHandler) getShot(w http.ResponseWriter, r *http.Request, id string) {
+	shot, err := h.store.GetByID(r.Context(), id)
+	if err != nil {
+		respondError(w, http.StatusNotFound, "ショットが見つかりません")
+		return
+	}
+	respondJSON(w, http.StatusOK, shot)
+}
+
+func (h *ShotHandler) createShot(w http.ResponseWriter, r *http.Request) {
+	var shot model.Shot
+	if err := json.NewDecoder(r.Body).Decode(&shot); err != nil {
+		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
+		return
+	}
+
+	if err := shot.Validate(); err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	created, err := h.store.Create(r.Context(), shot)
+	if err != nil {
+		respondError(w, http.StatusConflict, err.Error())
+		return
+	}
+	respondJSON(w, http.StatusCreated, created)
+}
+
+func (h *ShotHandler) updateShot(w http.ResponseWriter, r *http.Request, id string) {
+	var shot model.Shot
+	if err := json.NewDecoder(r.Body).Decode(&shot); err != nil {
+		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
+		return
+	}
+	shot.ID = id
+
+	if err := shot.Validate(); err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	updated, err := h.store.Update(r.Context(), shot)
+	if err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	respondJSON(w, http.StatusOK, updated)
+}
+
+func (h *ShotHandler) deleteShot(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.store.Delete(r.Context(), id); err != nil {
+		respondError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// extractIDFromPath はパスからIDを抽出する。
+func extractIDFromPath(path, prefix string) string {
+	trimmed := strings.TrimPrefix(path, prefix)
+	// スラッシュが含まれている場合は最初のセグメントのみ取得
+	if idx := strings.Index(trimmed, "/"); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+	return trimmed
+}

--- a/api/internal/handler/statistics.go
+++ b/api/internal/handler/statistics.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/service"
+	"github.com/ryusei/fairway-caddie/api/internal/store"
+)
+
+// StatsHandler は統計APIのハンドラ。
+type StatsHandler struct {
+	shotStore store.ShotStore
+}
+
+// NewStatsHandler は新しいStatsHandlerを作成する。
+func NewStatsHandler(s store.ShotStore) *StatsHandler {
+	return &StatsHandler{shotStore: s}
+}
+
+// HandleStats は /api/stats エンドポイントのハンドラ。
+// クエリパラメータ roundId でラウンド指定可能。
+func (h *StatsHandler) HandleStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		respondError(w, http.StatusMethodNotAllowed, "メソッドが許可されていません")
+		return
+	}
+
+	roundID := r.URL.Query().Get("roundId")
+	var shots []model.Shot
+	var err error
+
+	if roundID != "" {
+		shots, err = h.shotStore.ListByRound(r.Context(), roundID)
+	} else {
+		shots, err = h.shotStore.List(r.Context())
+	}
+
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "ショットの取得に失敗しました")
+		return
+	}
+
+	stats := service.CalculateClubStats(shots)
+	if stats == nil {
+		stats = []model.DistanceStats{}
+	}
+	respondJSON(w, http.StatusOK, stats)
+}

--- a/api/internal/middleware/cors.go
+++ b/api/internal/middleware/cors.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// CORS はCORSミドルウェアを返す。
+// 許可オリジンは環境変数 CORS_ALLOWED_ORIGINS で設定する (カンマ区切り)。
+// 未設定の場合はデフォルトで http://localhost:5173 を許可する。
+func CORS(next http.Handler) http.Handler {
+	allowedOriginsStr := os.Getenv("CORS_ALLOWED_ORIGINS")
+	var allowedOrigins []string
+	if allowedOriginsStr != "" {
+		for _, o := range strings.Split(allowedOriginsStr, ",") {
+			trimmed := strings.TrimSpace(o)
+			if trimmed != "" {
+				allowedOrigins = append(allowedOrigins, trimmed)
+			}
+		}
+	}
+	if len(allowedOrigins) == 0 {
+		allowedOrigins = []string{"http://localhost:5173"}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		allowed := false
+		for _, ao := range allowedOrigins {
+			if ao == origin {
+				allowed = true
+				break
+			}
+		}
+
+		if allowed {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+			w.Header().Set("Access-Control-Max-Age", "86400")
+		}
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/api/internal/middleware/cors_test.go
+++ b/api/internal/middleware/cors_test.go
@@ -1,0 +1,92 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/middleware"
+)
+
+func TestCORS_DefaultOrigin(t *testing.T) {
+	// CORS_ALLOWED_ORIGINS が未設定の場合、localhost:5173 を許可
+	if err := os.Unsetenv("CORS_ALLOWED_ORIGINS"); err != nil {
+		t.Fatalf("unsetenv error: %v", err)
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := middleware.CORS(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Errorf("ACAO = %q, want http://localhost:5173", got)
+	}
+}
+
+func TestCORS_PreflightOptions(t *testing.T) {
+	if err := os.Unsetenv("CORS_ALLOWED_ORIGINS"); err != nil {
+		t.Fatalf("unsetenv error: %v", err)
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := middleware.CORS(inner)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/test", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}
+
+func TestCORS_DisallowedOrigin(t *testing.T) {
+	if err := os.Unsetenv("CORS_ALLOWED_ORIGINS"); err != nil {
+		t.Fatalf("unsetenv error: %v", err)
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := middleware.CORS(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO should be empty for disallowed origin, got %q", got)
+	}
+}
+
+func TestCORS_CustomOrigins(t *testing.T) {
+	t.Setenv("CORS_ALLOWED_ORIGINS", "http://example.com, http://another.com")
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := middleware.CORS(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Origin", "http://example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://example.com" {
+		t.Errorf("ACAO = %q, want http://example.com", got)
+	}
+}

--- a/api/internal/middleware/logging.go
+++ b/api/internal/middleware/logging.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// responseWriter はステータスコードを記録するためのラッパー。
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Logging はリクエストログを出力するミドルウェアを返す。
+func Logging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rw, r)
+		log.Printf("%s %s %d %s", r.Method, r.URL.Path, rw.statusCode, time.Since(start))
+	})
+}

--- a/api/internal/model/club.go
+++ b/api/internal/model/club.go
@@ -1,0 +1,60 @@
+package model
+
+import "fmt"
+
+// ClubType はクラブ種別を表す。
+type ClubType string
+
+const (
+	ClubDriver ClubType = "driver"
+	Club3W     ClubType = "3w"
+	Club5W     ClubType = "5w"
+	Club7W     ClubType = "7w"
+	Club3I     ClubType = "3i"
+	Club4I     ClubType = "4i"
+	Club5I     ClubType = "5i"
+	Club6I     ClubType = "6i"
+	Club7I     ClubType = "7i"
+	Club8I     ClubType = "8i"
+	Club9I     ClubType = "9i"
+	ClubPW     ClubType = "pw"
+	ClubAW     ClubType = "aw"
+	ClubSW     ClubType = "sw"
+	ClubLW     ClubType = "lw"
+	ClubPutter ClubType = "putter"
+)
+
+// AllClubTypes は全クラブ種別のスライス。
+var AllClubTypes = []ClubType{
+	ClubDriver, Club3W, Club5W, Club7W,
+	Club3I, Club4I, Club5I, Club6I, Club7I, Club8I, Club9I,
+	ClubPW, ClubAW, ClubSW, ClubLW, ClubPutter,
+}
+
+// IsValidClubType はクラブ種別が有効か判定する。
+func IsValidClubType(s string) bool {
+	for _, ct := range AllClubTypes {
+		if string(ct) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Club はクラブ定義。
+type Club struct {
+	ID         string   `json:"id"`
+	Type       ClubType `json:"type"`
+	CustomName string   `json:"customName"`
+}
+
+// ValidateClubName はクラブ名のバリデーションを行う。
+func ValidateClubName(name string) error {
+	if len([]rune(name)) == 0 {
+		return fmt.Errorf("クラブ名は空にできません")
+	}
+	if len([]rune(name)) > 30 {
+		return fmt.Errorf("クラブ名は30文字以内にしてください")
+	}
+	return nil
+}

--- a/api/internal/model/club_test.go
+++ b/api/internal/model/club_test.go
@@ -1,0 +1,53 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+func TestIsValidClubType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"driver", "driver", true},
+		{"7i", "7i", true},
+		{"putter", "putter", true},
+		{"pw", "pw", true},
+		{"invalid", "invalid", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := model.IsValidClubType(tt.input)
+			if got != tt.want {
+				t.Errorf("IsValidClubType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateClubName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"有効な名前", "マイドライバー", false},
+		{"空文字", "", true},
+		{"30文字ちょうど", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false},
+		{"31文字", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := model.ValidateClubName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateClubName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/api/internal/model/coordinate.go
+++ b/api/internal/model/coordinate.go
@@ -1,0 +1,22 @@
+package model
+
+import "fmt"
+
+// Coordinate はコースマップ上のヤード座標を表す。
+type Coordinate struct {
+	// 縦位置 (ヤード, 0~150)
+	Lat float64 `json:"lat"`
+	// 横位置 (ヤード, 0~400)
+	Lng float64 `json:"lng"`
+}
+
+// Validate は座標のバリデーションを行う。
+func (c Coordinate) Validate() error {
+	if c.Lat < 0 || c.Lat > 150 {
+		return fmt.Errorf("縦位置は0~150ヤードの範囲で指定してください (got: %f)", c.Lat)
+	}
+	if c.Lng < 0 || c.Lng > 400 {
+		return fmt.Errorf("横位置は0~400ヤードの範囲で指定してください (got: %f)", c.Lng)
+	}
+	return nil
+}

--- a/api/internal/model/coordinate_test.go
+++ b/api/internal/model/coordinate_test.go
@@ -1,0 +1,32 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+func TestCoordinateValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		coord   model.Coordinate
+		wantErr bool
+	}{
+		{"有効な座標", model.Coordinate{Lat: 75, Lng: 200}, false},
+		{"境界値 (0,0)", model.Coordinate{Lat: 0, Lng: 0}, false},
+		{"境界値 (150,400)", model.Coordinate{Lat: 150, Lng: 400}, false},
+		{"Lat超過", model.Coordinate{Lat: 151, Lng: 0}, true},
+		{"Lat負値", model.Coordinate{Lat: -1, Lng: 0}, true},
+		{"Lng超過", model.Coordinate{Lat: 0, Lng: 401}, true},
+		{"Lng負値", model.Coordinate{Lat: 0, Lng: -1}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.coord.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/api/internal/model/course.go
+++ b/api/internal/model/course.go
@@ -1,0 +1,53 @@
+package model
+
+// HazardType はハザード種別を表す。
+type HazardType string
+
+const (
+	HazardBunker HazardType = "bunker"
+	HazardWater  HazardType = "water"
+	HazardOB     HazardType = "ob"
+	HazardTree   HazardType = "tree"
+	HazardRough  HazardType = "rough"
+)
+
+// AllHazardTypes は全ハザード種別。
+var AllHazardTypes = []HazardType{
+	HazardBunker, HazardWater, HazardOB, HazardTree, HazardRough,
+}
+
+// IsValidHazardType はハザード種別が有効か判定する。
+func IsValidHazardType(s string) bool {
+	for _, ht := range AllHazardTypes {
+		if string(ht) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Hazard はハザード定義。
+type Hazard struct {
+	ID          string     `json:"id"`
+	Type        HazardType `json:"type"`
+	Position    Coordinate `json:"position"`
+	RadiusYards float64    `json:"radiusYards"`
+}
+
+// Hole はホール定義。
+type Hole struct {
+	Number        int        `json:"number"`
+	Par           int        `json:"par"`
+	DistanceYards float64    `json:"distanceYards"`
+	TeePosition   Coordinate `json:"teePosition"`
+	PinPosition   Coordinate `json:"pinPosition"`
+	FairwayCenter Coordinate `json:"fairwayCenter"`
+	Hazards       []Hazard   `json:"hazards"`
+}
+
+// Course はコース定義。
+type Course struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Holes []Hole `json:"holes"`
+}

--- a/api/internal/model/course_test.go
+++ b/api/internal/model/course_test.go
@@ -1,0 +1,32 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+func TestIsValidHazardType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"bunker", "bunker", true},
+		{"water", "water", true},
+		{"ob", "ob", true},
+		{"tree", "tree", true},
+		{"rough", "rough", true},
+		{"invalid", "invalid", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := model.IsValidHazardType(tt.input)
+			if got != tt.want {
+				t.Errorf("IsValidHazardType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/api/internal/model/round.go
+++ b/api/internal/model/round.go
@@ -1,0 +1,54 @@
+package model
+
+import (
+	"fmt"
+	"time"
+)
+
+// Round はラウンド定義。
+type Round struct {
+	ID         string  `json:"id"`
+	CourseID   string  `json:"courseId"`
+	Date       string  `json:"date"`
+	Shots      []Shot  `json:"shots"`
+	TotalScore *int    `json:"totalScore"`
+}
+
+// Validate はラウンドのバリデーションを行う。
+func (r Round) Validate() error {
+	if r.ID == "" {
+		return fmt.Errorf("ラウンドIDは必須です")
+	}
+	if r.CourseID == "" {
+		return fmt.Errorf("コースIDは必須です")
+	}
+	if err := ValidateRoundDate(r.Date); err != nil {
+		return err
+	}
+	for i, s := range r.Shots {
+		if err := s.Validate(); err != nil {
+			return fmt.Errorf("ショット[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// ValidateRoundDate はラウンド日時のバリデーションを行う。
+func ValidateRoundDate(dateStr string) error {
+	if dateStr == "" {
+		return fmt.Errorf("日付は必須です")
+	}
+	// ISO8601 形式をまず試す
+	t, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		// YYYY-MM-DD 形式を試す
+		t, err = time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			return fmt.Errorf("有効な日付を指定してください")
+		}
+	}
+	if t.After(time.Now()) {
+		return fmt.Errorf("未来日のラウンドは登録できません")
+	}
+	return nil
+}

--- a/api/internal/model/round_test.go
+++ b/api/internal/model/round_test.go
@@ -1,0 +1,77 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+func TestValidateRoundDate(t *testing.T) {
+	tests := []struct {
+		name    string
+		date    string
+		wantErr bool
+	}{
+		{"有効な日付 (YYYY-MM-DD)", "2025-01-01", false},
+		{"有効な日付 (ISO8601)", "2025-01-01T00:00:00Z", false},
+		{"未来日", "2099-12-31T00:00:00Z", true},
+		{"不正な形式", "not-a-date", true},
+		{"空文字", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := model.ValidateRoundDate(tt.date)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRoundDate(%q) error = %v, wantErr %v", tt.date, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRoundValidate(t *testing.T) {
+	t.Run("有効なラウンド", func(t *testing.T) {
+		round := model.Round{
+			ID:       "round-1",
+			CourseID: "course-1",
+			Date:     "2025-06-01",
+			Shots:    []model.Shot{},
+		}
+		if err := round.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("空ID", func(t *testing.T) {
+		round := model.Round{
+			ID:       "",
+			CourseID: "course-1",
+			Date:     "2025-06-01",
+		}
+		if err := round.Validate(); err == nil {
+			t.Error("Validate() should return error for empty ID")
+		}
+	})
+
+	t.Run("空コースID", func(t *testing.T) {
+		round := model.Round{
+			ID:       "round-1",
+			CourseID: "",
+			Date:     "2025-06-01",
+		}
+		if err := round.Validate(); err == nil {
+			t.Error("Validate() should return error for empty CourseID")
+		}
+	})
+
+	t.Run("不正な日付", func(t *testing.T) {
+		round := model.Round{
+			ID:       "round-1",
+			CourseID: "course-1",
+			Date:     "invalid",
+		}
+		if err := round.Validate(); err == nil {
+			t.Error("Validate() should return error for invalid date")
+		}
+	})
+}

--- a/api/internal/model/shot.go
+++ b/api/internal/model/shot.go
@@ -1,0 +1,70 @@
+package model
+
+import (
+	"fmt"
+	"math"
+)
+
+// Shot はショット定義。
+type Shot struct {
+	ID              string     `json:"id"`
+	RoundID         string     `json:"roundId"`
+	HoleNumber      int        `json:"holeNumber"`
+	ShotNumber      int        `json:"shotNumber"`
+	Club            ClubType   `json:"club"`
+	Position        Coordinate `json:"position"`
+	LandingPosition Coordinate `json:"landingPosition"`
+	// 飛距離 (ヤード, 0~400)
+	DistanceYards float64 `json:"distanceYards"`
+	Timestamp     string  `json:"timestamp"`
+}
+
+// Validate はショットのバリデーションを行う。
+func (s Shot) Validate() error {
+	if s.ID == "" {
+		return fmt.Errorf("ショットIDは必須です")
+	}
+	if s.RoundID == "" {
+		return fmt.Errorf("ラウンドIDは必須です")
+	}
+	if s.HoleNumber < 1 || s.HoleNumber > 18 {
+		return fmt.Errorf("ホール番号は1~18の範囲で指定してください")
+	}
+	if s.ShotNumber < 1 {
+		return fmt.Errorf("ショット番号は1以上で指定してください")
+	}
+	if !IsValidClubType(string(s.Club)) {
+		return fmt.Errorf("無効なクラブ種別です: %s", s.Club)
+	}
+	if err := s.Position.Validate(); err != nil {
+		return fmt.Errorf("打点座標が不正です: %w", err)
+	}
+	if err := s.LandingPosition.Validate(); err != nil {
+		return fmt.Errorf("着弾座標が不正です: %w", err)
+	}
+	if err := ValidateDistance(s.DistanceYards); err != nil {
+		return err
+	}
+	if s.Timestamp == "" {
+		return fmt.Errorf("タイムスタンプは必須です")
+	}
+	return nil
+}
+
+// ValidateDistance は飛距離のバリデーションを行う。
+func ValidateDistance(distance float64) error {
+	if distance < 0 {
+		return fmt.Errorf("飛距離は0以上で指定してください")
+	}
+	if distance > 400 {
+		return fmt.Errorf("飛距離は400ヤード以下で指定してください")
+	}
+	return nil
+}
+
+// EuclideanDistanceYards は2点間のユークリッド距離(ヤード)を計算する。
+func EuclideanDistanceYards(from, to Coordinate) float64 {
+	dx := to.Lng - from.Lng
+	dy := to.Lat - from.Lat
+	return math.Sqrt(dx*dx + dy*dy)
+}

--- a/api/internal/model/shot_test.go
+++ b/api/internal/model/shot_test.go
@@ -1,0 +1,142 @@
+package model_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+func TestEuclideanDistanceYards(t *testing.T) {
+	tests := []struct {
+		name string
+		from model.Coordinate
+		to   model.Coordinate
+		want float64
+	}{
+		{
+			"同一地点",
+			model.Coordinate{Lat: 75, Lng: 0},
+			model.Coordinate{Lat: 75, Lng: 0},
+			0,
+		},
+		{
+			"水平方向",
+			model.Coordinate{Lat: 75, Lng: 0},
+			model.Coordinate{Lat: 75, Lng: 200},
+			200,
+		},
+		{
+			"垂直方向",
+			model.Coordinate{Lat: 0, Lng: 100},
+			model.Coordinate{Lat: 100, Lng: 100},
+			100,
+		},
+		{
+			"ピタゴラス (3-4-5)",
+			model.Coordinate{Lat: 0, Lng: 0},
+			model.Coordinate{Lat: 30, Lng: 40},
+			50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := model.EuclideanDistanceYards(tt.from, tt.to)
+			if math.Abs(got-tt.want) > 1e-6 {
+				t.Errorf("EuclideanDistanceYards() = %f, want %f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateDistance(t *testing.T) {
+	tests := []struct {
+		name     string
+		distance float64
+		wantErr  bool
+	}{
+		{"有効 (200)", 200, false},
+		{"境界値 (0)", 0, false},
+		{"境界値 (400)", 400, false},
+		{"負値", -1, true},
+		{"超過", 401, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := model.ValidateDistance(tt.distance)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDistance() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestShotValidate(t *testing.T) {
+	validShot := model.Shot{
+		ID:              "shot-1",
+		RoundID:         "round-1",
+		HoleNumber:      1,
+		ShotNumber:      1,
+		Club:            model.ClubDriver,
+		Position:        model.Coordinate{Lat: 75, Lng: 0},
+		LandingPosition: model.Coordinate{Lat: 75, Lng: 230},
+		DistanceYards:   230,
+		Timestamp:       "2026-01-01T00:00:00Z",
+	}
+
+	t.Run("有効なショット", func(t *testing.T) {
+		if err := validShot.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("空ID", func(t *testing.T) {
+		shot := validShot
+		shot.ID = ""
+		if err := shot.Validate(); err == nil {
+			t.Error("Validate() should return error for empty ID")
+		}
+	})
+
+	t.Run("空ラウンドID", func(t *testing.T) {
+		shot := validShot
+		shot.RoundID = ""
+		if err := shot.Validate(); err == nil {
+			t.Error("Validate() should return error for empty RoundID")
+		}
+	})
+
+	t.Run("無効なホール番号", func(t *testing.T) {
+		shot := validShot
+		shot.HoleNumber = 0
+		if err := shot.Validate(); err == nil {
+			t.Error("Validate() should return error for invalid hole number")
+		}
+	})
+
+	t.Run("無効なクラブ", func(t *testing.T) {
+		shot := validShot
+		shot.Club = "invalid"
+		if err := shot.Validate(); err == nil {
+			t.Error("Validate() should return error for invalid club")
+		}
+	})
+
+	t.Run("飛距離超過", func(t *testing.T) {
+		shot := validShot
+		shot.DistanceYards = 401
+		if err := shot.Validate(); err == nil {
+			t.Error("Validate() should return error for distance > 400")
+		}
+	})
+
+	t.Run("空タイムスタンプ", func(t *testing.T) {
+		shot := validShot
+		shot.Timestamp = ""
+		if err := shot.Validate(); err == nil {
+			t.Error("Validate() should return error for empty timestamp")
+		}
+	})
+}

--- a/api/internal/model/statistics.go
+++ b/api/internal/model/statistics.go
@@ -1,0 +1,32 @@
+package model
+
+// DistanceStats はクラブ別飛距離統計結果。
+type DistanceStats struct {
+	ClubType ClubType `json:"clubType"`
+	Count    int      `json:"count"`
+	Mean     float64  `json:"mean"`
+	Variance float64  `json:"variance"`
+	StdDev   float64  `json:"stdDev"`
+	Min      float64  `json:"min"`
+	Max      float64  `json:"max"`
+}
+
+// ClubRecommendation は推薦結果。
+type ClubRecommendation struct {
+	Club           ClubType `json:"club"`
+	ExpectedValue  float64  `json:"expectedValue"`
+	FairwayKeepRate float64 `json:"fairwayKeepRate"`
+	HazardRisk     float64  `json:"hazardRisk"`
+	DistanceMean   float64  `json:"distanceMean"`
+	DistanceStdDev float64  `json:"distanceStdDev"`
+	IsGeneric      bool     `json:"isGeneric"`
+}
+
+// RecommendRequest はクラブ推薦APIのリクエスト。
+type RecommendRequest struct {
+	CurrentPosition Coordinate `json:"currentPosition"`
+	TargetPosition  Coordinate `json:"targetPosition"`
+	Hazards         []Hazard   `json:"hazards"`
+	Shots           []Shot     `json:"shots"`
+	RoundCount      int        `json:"roundCount"`
+}

--- a/api/internal/service/recommendation.go
+++ b/api/internal/service/recommendation.go
@@ -1,0 +1,189 @@
+package service
+
+import (
+	"sort"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+// ハザード種別ごとのペナルティコスト。
+var hazardPenalty = map[model.HazardType]float64{
+	model.HazardWater:  2.0,
+	model.HazardBunker: 1.0,
+	model.HazardOB:     3.0,
+	model.HazardTree:   0.5,
+	model.HazardRough:  0.3,
+}
+
+// genericClubStats はコールドスタート用ジェネリック統計 (プロ平均ベース)。
+type genericClubStats struct {
+	Mean   float64
+	StdDev float64
+}
+
+var genericStats = map[model.ClubType]genericClubStats{
+	model.ClubDriver: {Mean: 230, StdDev: 20},
+	model.Club3W:     {Mean: 210, StdDev: 18},
+	model.Club5W:     {Mean: 195, StdDev: 16},
+	model.Club7W:     {Mean: 180, StdDev: 15},
+	model.Club3I:     {Mean: 180, StdDev: 14},
+	model.Club4I:     {Mean: 170, StdDev: 13},
+	model.Club5I:     {Mean: 160, StdDev: 12},
+	model.Club6I:     {Mean: 150, StdDev: 11},
+	model.Club7I:     {Mean: 140, StdDev: 10},
+	model.Club8I:     {Mean: 130, StdDev: 9},
+	model.Club9I:     {Mean: 120, StdDev: 8},
+	model.ClubPW:     {Mean: 110, StdDev: 7},
+	model.ClubAW:     {Mean: 95, StdDev: 6},
+	model.ClubSW:     {Mean: 80, StdDev: 5},
+	model.ClubLW:     {Mean: 60, StdDev: 5},
+	model.ClubPutter: {Mean: 10, StdDev: 3},
+}
+
+// RecommendationService はクラブ推薦サービス。
+type RecommendationService struct {
+	coldStartThreshold int
+}
+
+// NewRecommendationService は新しい推薦サービスを作成する。
+func NewRecommendationService(coldStartThreshold int) *RecommendationService {
+	if coldStartThreshold <= 0 {
+		coldStartThreshold = 5
+	}
+	return &RecommendationService{
+		coldStartThreshold: coldStartThreshold,
+	}
+}
+
+// Recommend はクラブ推薦を実行する。
+func (rs *RecommendationService) Recommend(
+	currentPosition model.Coordinate,
+	targetPosition model.Coordinate,
+	hazards []model.Hazard,
+	shots []model.Shot,
+	roundCount int,
+) []model.ClubRecommendation {
+	targetDistance := model.EuclideanDistanceYards(currentPosition, targetPosition)
+	isGeneric := roundCount < rs.coldStartThreshold
+	const tolerance = 15.0
+
+	var recommendations []model.ClubRecommendation
+
+	// 安定した順序のためAllClubTypesを使ってイテレートする
+	for _, club := range model.AllClubTypes {
+		gs, ok := genericStats[club]
+		if !ok {
+			continue
+		}
+
+		// putter はティーショット推薦対象外
+		if club == model.ClubPutter && targetDistance > 30 {
+			continue
+		}
+
+		var clubMean, clubStdDev float64
+		var useGeneric bool
+
+		if isGeneric {
+			clubMean = gs.Mean
+			clubStdDev = gs.StdDev
+			useGeneric = true
+		} else {
+			userStats := getClubDistanceStats(shots, club)
+			if userStats != nil && userStats.StdDev > 0 {
+				clubMean = userStats.Mean
+				clubStdDev = userStats.StdDev
+				useGeneric = false
+			} else {
+				clubMean = gs.Mean
+				clubStdDev = gs.StdDev
+				useGeneric = true
+			}
+		}
+
+		fairwayKeepRate := calculateFairwayRate(targetDistance, clubMean, clubStdDev, tolerance)
+		hazardRisk := calculateHazardRisk(currentPosition, hazards, clubMean, clubStdDev)
+
+		// 期待値 = フェアウェイキープ率 - ハザードリスク
+		expectedValue := fairwayKeepRate - hazardRisk
+
+		recommendations = append(recommendations, model.ClubRecommendation{
+			Club:            club,
+			ExpectedValue:   expectedValue,
+			FairwayKeepRate: fairwayKeepRate,
+			HazardRisk:      hazardRisk,
+			DistanceMean:    clubMean,
+			DistanceStdDev:  clubStdDev,
+			IsGeneric:       useGeneric,
+		})
+	}
+
+	// 期待値降順でソート
+	sort.Slice(recommendations, func(i, j int) bool {
+		return recommendations[i].ExpectedValue > recommendations[j].ExpectedValue
+	})
+
+	// 上位3つを返す
+	if len(recommendations) > 3 {
+		recommendations = recommendations[:3]
+	}
+
+	return recommendations
+}
+
+// getClubDistanceStats はクラブ別の飛距離統計を取得する。
+func getClubDistanceStats(shots []model.Shot, club model.ClubType) *genericClubStats {
+	var distances []float64
+	for _, s := range shots {
+		if s.Club == club {
+			distances = append(distances, s.DistanceYards)
+		}
+	}
+	if len(distances) == 0 {
+		return nil
+	}
+	return &genericClubStats{
+		Mean:   Mean(distances),
+		StdDev: StdDev(distances),
+	}
+}
+
+// calculateFairwayRate はフェアウェイ/グリーンオン確率を計算する。
+func calculateFairwayRate(targetDistance, clubMean, clubStdDev, tolerance float64) float64 {
+	if clubStdDev <= 0 {
+		if targetDistance == clubMean {
+			return 1
+		}
+		return 0
+	}
+	lower := NormalCdf(targetDistance-tolerance, clubMean, clubStdDev)
+	upper := NormalCdf(targetDistance+tolerance, clubMean, clubStdDev)
+	return upper - lower
+}
+
+// calculateHazardRisk はハザード到達確率を計算する。
+func calculateHazardRisk(
+	currentPosition model.Coordinate,
+	hazards []model.Hazard,
+	clubMean, clubStdDev float64,
+) float64 {
+	if len(hazards) == 0 || clubStdDev <= 0 {
+		return 0
+	}
+
+	var totalRisk float64
+	for _, hazard := range hazards {
+		hazardDistance := model.EuclideanDistanceYards(currentPosition, hazard.Position)
+		hazardNear := hazardDistance - hazard.RadiusYards
+		hazardFar := hazardDistance + hazard.RadiusYards
+
+		probability := NormalCdf(hazardFar, clubMean, clubStdDev) - NormalCdf(hazardNear, clubMean, clubStdDev)
+		penalty, ok := hazardPenalty[hazard.Type]
+		if !ok {
+			penalty = 1.0
+		}
+		totalRisk += probability * penalty
+	}
+
+	return totalRisk
+}

--- a/api/internal/service/recommendation_test.go
+++ b/api/internal/service/recommendation_test.go
@@ -1,0 +1,225 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/service"
+)
+
+func TestRecommendationService_ColdStart(t *testing.T) {
+	engine := service.NewRecommendationService(5)
+	teePosition := model.Coordinate{Lat: 75, Lng: 0}
+	targetPosition := model.Coordinate{Lat: 75, Lng: 230}
+
+	t.Run("5ラウンド未満ではジェネリック推薦", func(t *testing.T) {
+		recs := engine.Recommend(teePosition, targetPosition, nil, nil, 2)
+		if len(recs) != 3 {
+			t.Errorf("expected 3 recommendations, got %d", len(recs))
+		}
+		for _, rec := range recs {
+			if !rec.IsGeneric {
+				t.Errorf("expected generic recommendation for club %s", rec.Club)
+			}
+		}
+	})
+
+	t.Run("推薦結果は3つまで", func(t *testing.T) {
+		recs := engine.Recommend(teePosition, targetPosition, nil, nil, 0)
+		if len(recs) > 3 {
+			t.Errorf("expected at most 3 recommendations, got %d", len(recs))
+		}
+	})
+
+	t.Run("期待値降順ソート", func(t *testing.T) {
+		recs := engine.Recommend(teePosition, targetPosition, nil, nil, 0)
+		for i := 1; i < len(recs); i++ {
+			if recs[i-1].ExpectedValue < recs[i].ExpectedValue {
+				t.Errorf("recommendations not sorted by expected value: %f < %f",
+					recs[i-1].ExpectedValue, recs[i].ExpectedValue)
+			}
+		}
+	})
+
+	t.Run("推薦結果のフィールド確認", func(t *testing.T) {
+		recs := engine.Recommend(teePosition, targetPosition, nil, nil, 0)
+		for _, rec := range recs {
+			if rec.Club == "" {
+				t.Error("club should not be empty")
+			}
+			if rec.DistanceMean <= 0 {
+				t.Errorf("distanceMean should be > 0, got %f", rec.DistanceMean)
+			}
+			if rec.DistanceStdDev <= 0 {
+				t.Errorf("distanceStdDev should be > 0, got %f", rec.DistanceStdDev)
+			}
+		}
+	})
+}
+
+func TestRecommendationService_UserData(t *testing.T) {
+	engine := service.NewRecommendationService(5)
+	teePosition := model.Coordinate{Lat: 75, Lng: 0}
+
+	t.Run("5ラウンド以上でユーザーデータ使用", func(t *testing.T) {
+		shots := []model.Shot{
+			{Club: model.Club7I, DistanceYards: 140},
+			{Club: model.Club7I, DistanceYards: 145},
+			{Club: model.Club7I, DistanceYards: 135},
+			{Club: model.Club7I, DistanceYards: 142},
+			{Club: model.Club7I, DistanceYards: 138},
+		}
+		shortTarget := model.Coordinate{Lat: 75, Lng: 140}
+		recs := engine.Recommend(teePosition, shortTarget, nil, shots, 5)
+		found := false
+		for _, rec := range recs {
+			if rec.Club == model.Club7I {
+				found = true
+				if rec.IsGeneric {
+					t.Error("7i should use user data, not generic")
+				}
+			}
+		}
+		if !found {
+			// 7iが推薦に含まれない場合もあり得るのでスキップ
+			t.Log("7i not in top 3 recommendations")
+		}
+	})
+
+	t.Run("データなしクラブはジェネリックにフォールバック", func(t *testing.T) {
+		shots := []model.Shot{
+			{Club: model.Club7I, DistanceYards: 140},
+		}
+		targetPosition := model.Coordinate{Lat: 75, Lng: 230}
+		recs := engine.Recommend(teePosition, targetPosition, nil, shots, 5)
+		for _, rec := range recs {
+			if rec.Club == model.ClubDriver {
+				if !rec.IsGeneric {
+					t.Error("driver should be generic since no user data")
+				}
+			}
+		}
+	})
+}
+
+func TestRecommendationService_HazardRisk(t *testing.T) {
+	engine := service.NewRecommendationService(5)
+	teePosition := model.Coordinate{Lat: 75, Lng: 0}
+	targetPosition := model.Coordinate{Lat: 75, Lng: 230}
+
+	t.Run("ハザードなし: リスク0", func(t *testing.T) {
+		recs := engine.Recommend(teePosition, targetPosition, nil, nil, 0)
+		for _, rec := range recs {
+			if rec.HazardRisk != 0 {
+				t.Errorf("hazard risk should be 0 without hazards, got %f for %s",
+					rec.HazardRisk, rec.Club)
+			}
+		}
+	})
+
+	t.Run("ハザードありで期待値低下", func(t *testing.T) {
+		hazards := []model.Hazard{
+			{
+				ID:          "h1",
+				Type:        model.HazardWater,
+				Position:    model.Coordinate{Lat: 75, Lng: 230},
+				RadiusYards: 30,
+			},
+		}
+		withHazards := engine.Recommend(teePosition, targetPosition, hazards, nil, 0)
+		withoutHazards := engine.Recommend(teePosition, targetPosition, nil, nil, 0)
+
+		// ハザードありではトップのクラブが変わるか、期待値が下がる
+		if withHazards[0].Club == withoutHazards[0].Club {
+			if withHazards[0].ExpectedValue >= withoutHazards[0].ExpectedValue {
+				t.Error("hazards should decrease expected value")
+			}
+		}
+	})
+
+	t.Run("OBペナルティ > 水ペナルティ", func(t *testing.T) {
+		waterHazard := []model.Hazard{
+			{ID: "h1", Type: model.HazardWater, Position: model.Coordinate{Lat: 75, Lng: 200}, RadiusYards: 20},
+		}
+		obHazard := []model.Hazard{
+			{ID: "h1", Type: model.HazardOB, Position: model.Coordinate{Lat: 75, Lng: 200}, RadiusYards: 20},
+		}
+		waterRecs := engine.Recommend(teePosition, targetPosition, waterHazard, nil, 0)
+		obRecs := engine.Recommend(teePosition, targetPosition, obHazard, nil, 0)
+
+		for _, wr := range waterRecs {
+			for _, obr := range obRecs {
+				if wr.Club == obr.Club && wr.HazardRisk > 0 {
+					if obr.HazardRisk <= wr.HazardRisk {
+						t.Errorf("OB risk (%f) should be > water risk (%f) for %s",
+							obr.HazardRisk, wr.HazardRisk, wr.Club)
+					}
+				}
+			}
+		}
+	})
+}
+
+func TestRecommendationService_FairwayKeepRate(t *testing.T) {
+	engine := service.NewRecommendationService(5)
+	teePosition := model.Coordinate{Lat: 75, Lng: 0}
+	targetPosition := model.Coordinate{Lat: 75, Lng: 230}
+
+	t.Run("フェアウェイキープ率は0~1", func(t *testing.T) {
+		recs := engine.Recommend(teePosition, targetPosition, nil, nil, 0)
+		for _, rec := range recs {
+			if rec.FairwayKeepRate < 0 || rec.FairwayKeepRate > 1 {
+				t.Errorf("fairway keep rate out of range: %f for %s",
+					rec.FairwayKeepRate, rec.Club)
+			}
+		}
+	})
+}
+
+func TestRecommendationService_EdgeCases(t *testing.T) {
+	engine := service.NewRecommendationService(5)
+	teePosition := model.Coordinate{Lat: 75, Lng: 0}
+
+	t.Run("同一地点をターゲット", func(t *testing.T) {
+		recs := engine.Recommend(teePosition, teePosition, nil, nil, 0)
+		if len(recs) != 3 {
+			t.Errorf("expected 3 recommendations, got %d", len(recs))
+		}
+	})
+
+	t.Run("空ショットリストでジェネリック", func(t *testing.T) {
+		targetPosition := model.Coordinate{Lat: 75, Lng: 230}
+		recs := engine.Recommend(teePosition, targetPosition, nil, nil, 10)
+		for _, rec := range recs {
+			if !rec.IsGeneric {
+				t.Errorf("expected generic for club %s (no data)", rec.Club)
+			}
+		}
+	})
+
+	t.Run("大量ハザード", func(t *testing.T) {
+		targetPosition := model.Coordinate{Lat: 75, Lng: 230}
+		hazards := make([]model.Hazard, 50)
+		for i := range hazards {
+			hazards[i] = model.Hazard{
+				ID:          "h",
+				Type:        model.HazardBunker,
+				Position:    model.Coordinate{Lat: 75, Lng: float64(i * 8)},
+				RadiusYards: 10,
+			}
+		}
+		recs := engine.Recommend(teePosition, targetPosition, hazards, nil, 0)
+		if len(recs) != 3 {
+			t.Errorf("expected 3 recommendations, got %d", len(recs))
+		}
+	})
+
+	t.Run("カスタム閾値", func(t *testing.T) {
+		customEngine := service.NewRecommendationService(3)
+		targetPosition := model.Coordinate{Lat: 75, Lng: 230}
+		recs := customEngine.Recommend(teePosition, targetPosition, nil, nil, 3)
+		if len(recs) != 3 {
+			t.Errorf("expected 3 recommendations, got %d", len(recs))
+		}
+	})
+}

--- a/api/internal/service/statistics.go
+++ b/api/internal/service/statistics.go
@@ -1,0 +1,132 @@
+package service
+
+import (
+	"math"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+// Mean は平均を計算する。
+func Mean(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range values {
+		sum += v
+	}
+	return sum / float64(len(values))
+}
+
+// Variance は母分散を計算する。
+func Variance(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	avg := Mean(values)
+	var sumSq float64
+	for _, v := range values {
+		d := v - avg
+		sumSq += d * d
+	}
+	return sumSq / float64(len(values))
+}
+
+// StdDev は標準偏差を計算する。
+func StdDev(values []float64) float64 {
+	return math.Sqrt(Variance(values))
+}
+
+// GroupDistancesByClub はショットデータからクラブ別の飛距離リストを抽出する。
+func GroupDistancesByClub(shots []model.Shot) map[model.ClubType][]float64 {
+	result := make(map[model.ClubType][]float64)
+	for _, s := range shots {
+		result[s.Club] = append(result[s.Club], s.DistanceYards)
+	}
+	return result
+}
+
+// CalculateClubStats はクラブ別の飛距離統計を計算する。
+func CalculateClubStats(shots []model.Shot) []model.DistanceStats {
+	grouped := GroupDistancesByClub(shots)
+	var stats []model.DistanceStats
+
+	for clubType, distances := range grouped {
+		if len(distances) == 0 {
+			continue
+		}
+		stats = append(stats, model.DistanceStats{
+			ClubType: clubType,
+			Count:    len(distances),
+			Mean:     Mean(distances),
+			Variance: Variance(distances),
+			StdDev:   StdDev(distances),
+			Min:      minOf(distances),
+			Max:      maxOf(distances),
+		})
+	}
+
+	return stats
+}
+
+// NormalPdf は正規分布の確率密度関数 (PDF) を計算する。
+func NormalPdf(x, mu, sigma float64) float64 {
+	if sigma <= 0 {
+		return 0
+	}
+	z := (x - mu) / sigma
+	return math.Exp(-0.5*z*z) / (sigma * math.Sqrt(2*math.Pi))
+}
+
+// NormalCdf は正規分布の累積分布関数 (CDF) の近似を計算する。
+func NormalCdf(x, mu, sigma float64) float64 {
+	if sigma <= 0 {
+		if x >= mu {
+			return 1
+		}
+		return 0
+	}
+	z := (x - mu) / sigma
+	return 0.5 * (1 + erf(z/math.Sqrt2))
+}
+
+// erf は誤差関数の近似 (Abramowitz and Stegun)。
+func erf(x float64) float64 {
+	const (
+		a1 = 0.254829592
+		a2 = -0.284496736
+		a3 = 1.421413741
+		a4 = -1.453152027
+		a5 = 1.061405429
+		p  = 0.3275911
+	)
+
+	sign := 1.0
+	if x < 0 {
+		sign = -1.0
+	}
+	absX := math.Abs(x)
+	t := 1.0 / (1.0 + p*absX)
+	y := 1.0 - ((((a5*t+a4)*t+a3)*t+a2)*t+a1)*t*math.Exp(-absX*absX)
+	return sign * y
+}
+
+func minOf(values []float64) float64 {
+	result := math.Inf(1)
+	for _, v := range values {
+		if v < result {
+			result = v
+		}
+	}
+	return result
+}
+
+func maxOf(values []float64) float64 {
+	result := math.Inf(-1)
+	for _, v := range values {
+		if v > result {
+			result = v
+		}
+	}
+	return result
+}

--- a/api/internal/service/statistics_test.go
+++ b/api/internal/service/statistics_test.go
@@ -1,0 +1,201 @@
+package service_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/service"
+)
+
+func TestMean(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []float64
+		want   float64
+	}{
+		{"空配列", nil, 0},
+		{"単一要素", []float64{5}, 5},
+		{"複数要素", []float64{1, 2, 3, 4, 5}, 3},
+		{"小数", []float64{10.5, 20.5}, 15.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := service.Mean(tt.values)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("Mean() = %f, want %f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVariance(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []float64
+		want   float64
+	}{
+		{"空配列", nil, 0},
+		{"同一値", []float64{5, 5, 5}, 0},
+		{"母分散", []float64{2, 4, 4, 4, 5, 5, 7, 9}, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := service.Variance(tt.values)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("Variance() = %f, want %f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStdDev(t *testing.T) {
+	t.Run("空配列", func(t *testing.T) {
+		got := service.StdDev(nil)
+		if got != 0 {
+			t.Errorf("StdDev(nil) = %f, want 0", got)
+		}
+	})
+
+	t.Run("variance=4 → stdDev=2", func(t *testing.T) {
+		got := service.StdDev([]float64{2, 4, 4, 4, 5, 5, 7, 9})
+		if math.Abs(got-2) > 1e-9 {
+			t.Errorf("StdDev() = %f, want 2", got)
+		}
+	})
+}
+
+func TestNormalPdf(t *testing.T) {
+	t.Run("sigma<=0", func(t *testing.T) {
+		if service.NormalPdf(0, 0, 0) != 0 {
+			t.Error("NormalPdf(0,0,0) should be 0")
+		}
+		if service.NormalPdf(0, 0, -1) != 0 {
+			t.Error("NormalPdf(0,0,-1) should be 0")
+		}
+	})
+
+	t.Run("N(0,1)の中心", func(t *testing.T) {
+		got := service.NormalPdf(0, 0, 1)
+		if math.Abs(got-0.3989) > 0.001 {
+			t.Errorf("NormalPdf(0,0,1) = %f, want ~0.3989", got)
+		}
+	})
+
+	t.Run("中心が離れると値が小さくなる", func(t *testing.T) {
+		center := service.NormalPdf(230, 230, 15)
+		away := service.NormalPdf(260, 230, 15)
+		if center <= away {
+			t.Errorf("center (%f) should be > away (%f)", center, away)
+		}
+	})
+}
+
+func TestNormalCdf(t *testing.T) {
+	t.Run("sigma<=0", func(t *testing.T) {
+		if service.NormalCdf(0, 0, 0) != 1 {
+			t.Error("NormalCdf(0,0,0) should be 1")
+		}
+		if service.NormalCdf(-1, 0, 0) != 0 {
+			t.Error("NormalCdf(-1,0,0) should be 0")
+		}
+	})
+
+	t.Run("N(0,1)の中心", func(t *testing.T) {
+		got := service.NormalCdf(0, 0, 1)
+		if math.Abs(got-0.5) > 0.001 {
+			t.Errorf("NormalCdf(0,0,1) = %f, want ~0.5", got)
+		}
+	})
+
+	t.Run("+1σ", func(t *testing.T) {
+		got := service.NormalCdf(1, 0, 1)
+		if math.Abs(got-0.8413) > 0.001 {
+			t.Errorf("NormalCdf(1,0,1) = %f, want ~0.8413", got)
+		}
+	})
+
+	t.Run("-1σ", func(t *testing.T) {
+		got := service.NormalCdf(-1, 0, 1)
+		if math.Abs(got-0.1587) > 0.001 {
+			t.Errorf("NormalCdf(-1,0,1) = %f, want ~0.1587", got)
+		}
+	})
+}
+
+func TestGroupDistancesByClub(t *testing.T) {
+	t.Run("空配列", func(t *testing.T) {
+		result := service.GroupDistancesByClub(nil)
+		if len(result) != 0 {
+			t.Errorf("expected empty map, got %d entries", len(result))
+		}
+	})
+
+	t.Run("クラブ別分類", func(t *testing.T) {
+		shots := []model.Shot{
+			{Club: model.ClubDriver, DistanceYards: 230},
+			{Club: model.ClubDriver, DistanceYards: 240},
+			{Club: model.Club7I, DistanceYards: 150},
+		}
+		result := service.GroupDistancesByClub(shots)
+		driverDistances := result[model.ClubDriver]
+		if len(driverDistances) != 2 {
+			t.Errorf("driver should have 2 distances, got %d", len(driverDistances))
+		}
+		ironDistances := result[model.Club7I]
+		if len(ironDistances) != 1 {
+			t.Errorf("7i should have 1 distance, got %d", len(ironDistances))
+		}
+	})
+}
+
+func TestCalculateClubStats(t *testing.T) {
+	t.Run("空配列", func(t *testing.T) {
+		stats := service.CalculateClubStats(nil)
+		if len(stats) != 0 {
+			t.Errorf("expected empty stats, got %d", len(stats))
+		}
+	})
+
+	t.Run("ドライバー統計", func(t *testing.T) {
+		shots := []model.Shot{
+			{Club: model.ClubDriver, DistanceYards: 220},
+			{Club: model.ClubDriver, DistanceYards: 240},
+			{Club: model.ClubDriver, DistanceYards: 230},
+		}
+		stats := service.CalculateClubStats(shots)
+		if len(stats) != 1 {
+			t.Fatalf("expected 1 club stat, got %d", len(stats))
+		}
+		s := stats[0]
+		if s.ClubType != model.ClubDriver {
+			t.Errorf("expected driver, got %s", s.ClubType)
+		}
+		if s.Count != 3 {
+			t.Errorf("count = %d, want 3", s.Count)
+		}
+		if math.Abs(s.Mean-230) > 0.01 {
+			t.Errorf("mean = %f, want 230", s.Mean)
+		}
+		if s.Min != 220 {
+			t.Errorf("min = %f, want 220", s.Min)
+		}
+		if s.Max != 240 {
+			t.Errorf("max = %f, want 240", s.Max)
+		}
+	})
+
+	t.Run("複数クラブ", func(t *testing.T) {
+		shots := []model.Shot{
+			{Club: model.ClubDriver, DistanceYards: 230},
+			{Club: model.Club7I, DistanceYards: 150},
+			{Club: model.ClubPW, DistanceYards: 100},
+		}
+		stats := service.CalculateClubStats(shots)
+		if len(stats) != 3 {
+			t.Errorf("expected 3 club stats, got %d", len(stats))
+		}
+	})
+}

--- a/api/internal/store/memory.go
+++ b/api/internal/store/memory.go
@@ -1,0 +1,264 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+)
+
+// ShotStore はショットデータのストアインターフェース。
+type ShotStore interface {
+	List(ctx context.Context) ([]model.Shot, error)
+	ListByRound(ctx context.Context, roundID string) ([]model.Shot, error)
+	GetByID(ctx context.Context, id string) (model.Shot, error)
+	Create(ctx context.Context, shot model.Shot) (model.Shot, error)
+	Update(ctx context.Context, shot model.Shot) (model.Shot, error)
+	Delete(ctx context.Context, id string) error
+}
+
+// RoundStore はラウンドデータのストアインターフェース。
+type RoundStore interface {
+	List(ctx context.Context) ([]model.Round, error)
+	GetByID(ctx context.Context, id string) (model.Round, error)
+	Create(ctx context.Context, round model.Round) (model.Round, error)
+	Update(ctx context.Context, round model.Round) (model.Round, error)
+	Delete(ctx context.Context, id string) error
+	Count(ctx context.Context) (int, error)
+}
+
+// CourseStore はコースデータのストアインターフェース。
+type CourseStore interface {
+	List(ctx context.Context) ([]model.Course, error)
+	GetByID(ctx context.Context, id string) (model.Course, error)
+}
+
+// MemoryShotStore はインメモリのショットストア。
+type MemoryShotStore struct {
+	mu    sync.RWMutex
+	shots map[string]model.Shot
+	order []string
+}
+
+// NewMemoryShotStore は新しいインメモリショットストアを作成する。
+func NewMemoryShotStore() *MemoryShotStore {
+	return &MemoryShotStore{
+		shots: make(map[string]model.Shot),
+	}
+}
+
+func (s *MemoryShotStore) List(_ context.Context) ([]model.Shot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]model.Shot, 0, len(s.order))
+	for _, id := range s.order {
+		if shot, ok := s.shots[id]; ok {
+			result = append(result, shot)
+		}
+	}
+	return result, nil
+}
+
+func (s *MemoryShotStore) ListByRound(_ context.Context, roundID string) ([]model.Shot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []model.Shot
+	for _, id := range s.order {
+		if shot, ok := s.shots[id]; ok && shot.RoundID == roundID {
+			result = append(result, shot)
+		}
+	}
+	return result, nil
+}
+
+func (s *MemoryShotStore) GetByID(_ context.Context, id string) (model.Shot, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	shot, ok := s.shots[id]
+	if !ok {
+		return model.Shot{}, fmt.Errorf("ショットが見つかりません: %s", id)
+	}
+	return shot, nil
+}
+
+func (s *MemoryShotStore) Create(_ context.Context, shot model.Shot) (model.Shot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.shots[shot.ID]; exists {
+		return model.Shot{}, fmt.Errorf("ショットID %s は既に存在します", shot.ID)
+	}
+	s.shots[shot.ID] = shot
+	s.order = append(s.order, shot.ID)
+	return shot, nil
+}
+
+func (s *MemoryShotStore) Update(_ context.Context, shot model.Shot) (model.Shot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.shots[shot.ID]; !exists {
+		return model.Shot{}, fmt.Errorf("ショットが見つかりません: %s", shot.ID)
+	}
+	s.shots[shot.ID] = shot
+	return shot, nil
+}
+
+func (s *MemoryShotStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.shots[id]; !exists {
+		return fmt.Errorf("ショットが見つかりません: %s", id)
+	}
+	delete(s.shots, id)
+	newOrder := make([]string, 0, len(s.order)-1)
+	for _, oid := range s.order {
+		if oid != id {
+			newOrder = append(newOrder, oid)
+		}
+	}
+	s.order = newOrder
+	return nil
+}
+
+// MemoryRoundStore はインメモリのラウンドストア。
+type MemoryRoundStore struct {
+	mu     sync.RWMutex
+	rounds map[string]model.Round
+	order  []string
+}
+
+// NewMemoryRoundStore は新しいインメモリラウンドストアを作成する。
+func NewMemoryRoundStore() *MemoryRoundStore {
+	return &MemoryRoundStore{
+		rounds: make(map[string]model.Round),
+	}
+}
+
+func (s *MemoryRoundStore) List(_ context.Context) ([]model.Round, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]model.Round, 0, len(s.order))
+	for _, id := range s.order {
+		if round, ok := s.rounds[id]; ok {
+			result = append(result, round)
+		}
+	}
+	return result, nil
+}
+
+func (s *MemoryRoundStore) GetByID(_ context.Context, id string) (model.Round, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	round, ok := s.rounds[id]
+	if !ok {
+		return model.Round{}, fmt.Errorf("ラウンドが見つかりません: %s", id)
+	}
+	return round, nil
+}
+
+func (s *MemoryRoundStore) Create(_ context.Context, round model.Round) (model.Round, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.rounds[round.ID]; exists {
+		return model.Round{}, fmt.Errorf("ラウンドID %s は既に存在します", round.ID)
+	}
+	s.rounds[round.ID] = round
+	s.order = append(s.order, round.ID)
+	return round, nil
+}
+
+func (s *MemoryRoundStore) Update(_ context.Context, round model.Round) (model.Round, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.rounds[round.ID]; !exists {
+		return model.Round{}, fmt.Errorf("ラウンドが見つかりません: %s", round.ID)
+	}
+	s.rounds[round.ID] = round
+	return round, nil
+}
+
+func (s *MemoryRoundStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.rounds[id]; !exists {
+		return fmt.Errorf("ラウンドが見つかりません: %s", id)
+	}
+	delete(s.rounds, id)
+	newOrder := make([]string, 0, len(s.order)-1)
+	for _, oid := range s.order {
+		if oid != id {
+			newOrder = append(newOrder, oid)
+		}
+	}
+	s.order = newOrder
+	return nil
+}
+
+func (s *MemoryRoundStore) Count(_ context.Context) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.rounds), nil
+}
+
+// MemoryCourseStore はインメモリのコースストア（モックデータ付き）。
+type MemoryCourseStore struct {
+	courses map[string]model.Course
+	order   []string
+}
+
+// NewMemoryCourseStore は新しいインメモリコースストアをモックデータ付きで作成する。
+func NewMemoryCourseStore() *MemoryCourseStore {
+	mockCourse := model.Course{
+		ID:   "mock-course-001",
+		Name: "サンプルゴルフコース",
+		Holes: []model.Hole{
+			{
+				Number:        1,
+				Par:           4,
+				DistanceYards: 370,
+				TeePosition:   model.Coordinate{Lat: 75, Lng: 0},
+				PinPosition:   model.Coordinate{Lat: 75, Lng: 370},
+				FairwayCenter: model.Coordinate{Lat: 75, Lng: 185},
+				Hazards: []model.Hazard{
+					{
+						ID:          "h-bunker-1",
+						Type:        model.HazardBunker,
+						Position:    model.Coordinate{Lat: 120, Lng: 200},
+						RadiusYards: 15,
+					},
+					{
+						ID:          "h-water-1",
+						Type:        model.HazardWater,
+						Position:    model.Coordinate{Lat: 30, Lng: 280},
+						RadiusYards: 20,
+					},
+				},
+			},
+		},
+	}
+
+	return &MemoryCourseStore{
+		courses: map[string]model.Course{
+			mockCourse.ID: mockCourse,
+		},
+		order: []string{mockCourse.ID},
+	}
+}
+
+func (s *MemoryCourseStore) List(_ context.Context) ([]model.Course, error) {
+	result := make([]model.Course, 0, len(s.order))
+	for _, id := range s.order {
+		if course, ok := s.courses[id]; ok {
+			result = append(result, course)
+		}
+	}
+	return result, nil
+}
+
+func (s *MemoryCourseStore) GetByID(_ context.Context, id string) (model.Course, error) {
+	course, ok := s.courses[id]
+	if !ok {
+		return model.Course{}, fmt.Errorf("コースが見つかりません: %s", id)
+	}
+	return course, nil
+}

--- a/api/internal/store/memory_test.go
+++ b/api/internal/store/memory_test.go
@@ -1,0 +1,257 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ryusei/fairway-caddie/api/internal/model"
+	"github.com/ryusei/fairway-caddie/api/internal/store"
+)
+
+func TestMemoryShotStore_CRUD(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryShotStore()
+
+	shot := model.Shot{
+		ID:              "shot-1",
+		RoundID:         "round-1",
+		HoleNumber:      1,
+		ShotNumber:      1,
+		Club:            model.ClubDriver,
+		Position:        model.Coordinate{Lat: 75, Lng: 0},
+		LandingPosition: model.Coordinate{Lat: 75, Lng: 230},
+		DistanceYards:   230,
+		Timestamp:       "2026-01-01T00:00:00Z",
+	}
+
+	t.Run("Create", func(t *testing.T) {
+		created, err := s.Create(ctx, shot)
+		if err != nil {
+			t.Fatalf("Create() error: %v", err)
+		}
+		if created.ID != shot.ID {
+			t.Errorf("created ID = %s, want %s", created.ID, shot.ID)
+		}
+	})
+
+	t.Run("Create_重複", func(t *testing.T) {
+		_, err := s.Create(ctx, shot)
+		if err == nil {
+			t.Error("Create() should return error for duplicate ID")
+		}
+	})
+
+	t.Run("GetByID", func(t *testing.T) {
+		got, err := s.GetByID(ctx, "shot-1")
+		if err != nil {
+			t.Fatalf("GetByID() error: %v", err)
+		}
+		if got.DistanceYards != 230 {
+			t.Errorf("distance = %f, want 230", got.DistanceYards)
+		}
+	})
+
+	t.Run("GetByID_存在しない", func(t *testing.T) {
+		_, err := s.GetByID(ctx, "nonexistent")
+		if err == nil {
+			t.Error("GetByID() should return error for nonexistent ID")
+		}
+	})
+
+	t.Run("List", func(t *testing.T) {
+		shots, err := s.List(ctx)
+		if err != nil {
+			t.Fatalf("List() error: %v", err)
+		}
+		if len(shots) != 1 {
+			t.Errorf("List() returned %d shots, want 1", len(shots))
+		}
+	})
+
+	t.Run("ListByRound", func(t *testing.T) {
+		shot2 := model.Shot{
+			ID:              "shot-2",
+			RoundID:         "round-2",
+			HoleNumber:      1,
+			ShotNumber:      1,
+			Club:            model.Club7I,
+			Position:        model.Coordinate{Lat: 75, Lng: 0},
+			LandingPosition: model.Coordinate{Lat: 75, Lng: 140},
+			DistanceYards:   140,
+			Timestamp:       "2026-01-01T00:00:00Z",
+		}
+		if _, err := s.Create(ctx, shot2); err != nil {
+			t.Fatalf("Create shot2 error: %v", err)
+		}
+
+		shots, err := s.ListByRound(ctx, "round-1")
+		if err != nil {
+			t.Fatalf("ListByRound() error: %v", err)
+		}
+		if len(shots) != 1 {
+			t.Errorf("ListByRound() returned %d shots, want 1", len(shots))
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		updated := shot
+		updated.DistanceYards = 250
+		result, err := s.Update(ctx, updated)
+		if err != nil {
+			t.Fatalf("Update() error: %v", err)
+		}
+		if result.DistanceYards != 250 {
+			t.Errorf("updated distance = %f, want 250", result.DistanceYards)
+		}
+	})
+
+	t.Run("Update_存在しない", func(t *testing.T) {
+		_, err := s.Update(ctx, model.Shot{ID: "nonexistent"})
+		if err == nil {
+			t.Error("Update() should return error for nonexistent ID")
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		if err := s.Delete(ctx, "shot-1"); err != nil {
+			t.Fatalf("Delete() error: %v", err)
+		}
+		_, err := s.GetByID(ctx, "shot-1")
+		if err == nil {
+			t.Error("GetByID() should return error after delete")
+		}
+	})
+
+	t.Run("Delete_存在しない", func(t *testing.T) {
+		if err := s.Delete(ctx, "nonexistent"); err == nil {
+			t.Error("Delete() should return error for nonexistent ID")
+		}
+	})
+}
+
+func TestMemoryRoundStore_CRUD(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryRoundStore()
+
+	round := model.Round{
+		ID:       "round-1",
+		CourseID: "course-1",
+		Date:     "2025-06-01",
+		Shots:    []model.Shot{},
+	}
+
+	t.Run("Create", func(t *testing.T) {
+		created, err := s.Create(ctx, round)
+		if err != nil {
+			t.Fatalf("Create() error: %v", err)
+		}
+		if created.ID != round.ID {
+			t.Errorf("created ID = %s, want %s", created.ID, round.ID)
+		}
+	})
+
+	t.Run("Create_重複", func(t *testing.T) {
+		_, err := s.Create(ctx, round)
+		if err == nil {
+			t.Error("Create() should return error for duplicate ID")
+		}
+	})
+
+	t.Run("GetByID", func(t *testing.T) {
+		got, err := s.GetByID(ctx, "round-1")
+		if err != nil {
+			t.Fatalf("GetByID() error: %v", err)
+		}
+		if got.CourseID != "course-1" {
+			t.Errorf("courseId = %s, want course-1", got.CourseID)
+		}
+	})
+
+	t.Run("List", func(t *testing.T) {
+		rounds, err := s.List(ctx)
+		if err != nil {
+			t.Fatalf("List() error: %v", err)
+		}
+		if len(rounds) != 1 {
+			t.Errorf("List() returned %d rounds, want 1", len(rounds))
+		}
+	})
+
+	t.Run("Count", func(t *testing.T) {
+		count, err := s.Count(ctx)
+		if err != nil {
+			t.Fatalf("Count() error: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("Count() = %d, want 1", count)
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		score := 85
+		updated := round
+		updated.TotalScore = &score
+		result, err := s.Update(ctx, updated)
+		if err != nil {
+			t.Fatalf("Update() error: %v", err)
+		}
+		if result.TotalScore == nil || *result.TotalScore != 85 {
+			t.Error("TotalScore should be 85")
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		if err := s.Delete(ctx, "round-1"); err != nil {
+			t.Fatalf("Delete() error: %v", err)
+		}
+		count, err := s.Count(ctx)
+		if err != nil {
+			t.Fatalf("Count() error: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("Count() = %d after delete, want 0", count)
+		}
+	})
+}
+
+func TestMemoryCourseStore(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryCourseStore()
+
+	t.Run("List", func(t *testing.T) {
+		courses, err := s.List(ctx)
+		if err != nil {
+			t.Fatalf("List() error: %v", err)
+		}
+		if len(courses) == 0 {
+			t.Error("List() should return at least 1 course (mock data)")
+		}
+		if courses[0].Name != "サンプルゴルフコース" {
+			t.Errorf("course name = %s, want サンプルゴルフコース", courses[0].Name)
+		}
+	})
+
+	t.Run("GetByID_モックコース", func(t *testing.T) {
+		course, err := s.GetByID(ctx, "mock-course-001")
+		if err != nil {
+			t.Fatalf("GetByID() error: %v", err)
+		}
+		if len(course.Holes) == 0 {
+			t.Error("mock course should have holes")
+		}
+		hole := course.Holes[0]
+		if hole.Par != 4 {
+			t.Errorf("hole 1 par = %d, want 4", hole.Par)
+		}
+		if len(hole.Hazards) != 2 {
+			t.Errorf("hole 1 hazards = %d, want 2", len(hole.Hazards))
+		}
+	})
+
+	t.Run("GetByID_存在しない", func(t *testing.T) {
+		_, err := s.GetByID(ctx, "nonexistent")
+		if err == nil {
+			t.Error("GetByID() should return error for nonexistent ID")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Go REST API実装（ショットCRUD・統計計算・クラブ推薦）
- FEの統計計算・推薦ロジックをGoに忠実に移植
- 標準ライブラリのみ使用、外部依存ゼロ

## Test plan
- [x] Go API 41テスト全パス (model/service/store/handler/middleware)
- [x] FE既存90テスト全パス
- [x] lint/typecheck 全パス