### PR TITLE
Codexレビュー指摘修正: Round/Shot同期・日付TZ・推薦バリデーション・ヘルス405

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	// ハンドラ初期化
 	shotHandler := handler.NewShotHandler(shotStore)
-	roundHandler := handler.NewRoundHandler(roundStore)
+	roundHandler := handler.NewRoundHandler(roundStore, shotStore)
 	courseHandler := handler.NewCourseHandler(courseStore)
 	statsHandler := handler.NewStatsHandler(shotStore)
 	recommendHandler := handler.NewRecommendationHandler(recommendService)
@@ -43,7 +43,11 @@ func main() {
 	// ヘルスチェック
 	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			http.Error(w, `{"error":"メソッドが許可されていません"}`, http.StatusMethodNotAllowed)
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			if _, err := w.Write([]byte(`{"error":"メソッドが許可されていません"}`)); err != nil {
+				log.Printf("ヘルスチェックエラーレスポンスの書き込みに失敗: %v", err)
+			}
 			return
 		}
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/api/internal/handler/handler_test.go
+++ b/api/internal/handler/handler_test.go
@@ -19,10 +19,11 @@ func setupShotHandler() (*handler.ShotHandler, *store.MemoryShotStore) {
 	return h, s
 }
 
-func setupRoundHandler() (*handler.RoundHandler, *store.MemoryRoundStore) {
+func setupRoundHandler() (*handler.RoundHandler, *store.MemoryRoundStore, *store.MemoryShotStore) {
 	s := store.NewMemoryRoundStore()
-	h := handler.NewRoundHandler(s)
-	return h, s
+	ss := store.NewMemoryShotStore()
+	h := handler.NewRoundHandler(s, ss)
+	return h, s, ss
 }
 
 func validShot() model.Shot {
@@ -224,7 +225,7 @@ func TestShotHandler_ListByRound(t *testing.T) {
 }
 
 func TestRoundHandler_CreateAndList(t *testing.T) {
-	h, _ := setupRoundHandler()
+	h, _, _ := setupRoundHandler()
 
 	body, marshalErr := json.Marshal(validRound())
 	if marshalErr != nil {
@@ -407,4 +408,158 @@ func TestRecommendationHandler(t *testing.T) {
 			t.Errorf("POST /api/recommend with invalid coordinate status = %d, want %d", w.Code, http.StatusBadRequest)
 		}
 	})
+
+	t.Run("不正なクラブ種別のショット", func(t *testing.T) {
+		invalidReq := model.RecommendRequest{
+			CurrentPosition: model.Coordinate{Lat: 75, Lng: 0},
+			TargetPosition:  model.Coordinate{Lat: 75, Lng: 230},
+			Hazards:         []model.Hazard{},
+			Shots: []model.Shot{
+				{
+					ID:              "shot-1",
+					RoundID:         "round-1",
+					HoleNumber:      1,
+					ShotNumber:      1,
+					Club:            "invalid-club",
+					Position:        model.Coordinate{Lat: 75, Lng: 0},
+					LandingPosition: model.Coordinate{Lat: 75, Lng: 230},
+					DistanceYards:   230,
+					Timestamp:       "2026-01-01T00:00:00Z",
+				},
+			},
+		}
+		invalidBody, marshalErr := json.Marshal(invalidReq)
+		if marshalErr != nil {
+			t.Fatalf("marshal error: %v", marshalErr)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/recommend", bytes.NewReader(invalidBody))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleRecommend(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("POST /api/recommend with invalid club status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("負の飛距離のショット", func(t *testing.T) {
+		invalidReq := model.RecommendRequest{
+			CurrentPosition: model.Coordinate{Lat: 75, Lng: 0},
+			TargetPosition:  model.Coordinate{Lat: 75, Lng: 230},
+			Hazards:         []model.Hazard{},
+			Shots: []model.Shot{
+				{
+					ID:              "shot-1",
+					RoundID:         "round-1",
+					HoleNumber:      1,
+					ShotNumber:      1,
+					Club:            model.ClubDriver,
+					Position:        model.Coordinate{Lat: 75, Lng: 0},
+					LandingPosition: model.Coordinate{Lat: 75, Lng: 230},
+					DistanceYards:   -10,
+					Timestamp:       "2026-01-01T00:00:00Z",
+				},
+			},
+		}
+		invalidBody, marshalErr := json.Marshal(invalidReq)
+		if marshalErr != nil {
+			t.Fatalf("marshal error: %v", marshalErr)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/recommend", bytes.NewReader(invalidBody))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleRecommend(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("POST /api/recommend with negative distance status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("不正なハザード種別", func(t *testing.T) {
+		invalidReq := model.RecommendRequest{
+			CurrentPosition: model.Coordinate{Lat: 75, Lng: 0},
+			TargetPosition:  model.Coordinate{Lat: 75, Lng: 230},
+			Hazards: []model.Hazard{
+				{
+					ID:          "h-1",
+					Type:        "invalid-hazard",
+					Position:    model.Coordinate{Lat: 75, Lng: 100},
+					RadiusYards: 10,
+				},
+			},
+			Shots: []model.Shot{},
+		}
+		invalidBody, marshalErr := json.Marshal(invalidReq)
+		if marshalErr != nil {
+			t.Fatalf("marshal error: %v", marshalErr)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/recommend", bytes.NewReader(invalidBody))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.HandleRecommend(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("POST /api/recommend with invalid hazard type status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+}
+
+func TestRoundHandler_ShotSync(t *testing.T) {
+	h, roundStore, shotStore := setupRoundHandler()
+
+	// ラウンドを作成
+	round := validRound()
+	body, marshalErr := json.Marshal(round)
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/rounds", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleRounds(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST /api/rounds status = %d, want %d. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	// ShotStoreにショットを直接追加
+	shot := validShot()
+	if _, err := shotStore.Create(nil, shot); err != nil {
+		t.Fatalf("create shot error: %v", err)
+	}
+
+	// GET /api/rounds/round-1 でショットが含まれることを確認
+	req = httptest.NewRequest(http.MethodGet, "/api/rounds/round-1", nil)
+	w = httptest.NewRecorder()
+	h.HandleRoundByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/rounds/round-1 status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var gotRound model.Round
+	if err := json.NewDecoder(w.Body).Decode(&gotRound); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(gotRound.Shots) != 1 {
+		t.Errorf("expected 1 shot in round, got %d", len(gotRound.Shots))
+	}
+
+	// GET /api/rounds（一覧）でもショットが含まれることを確認
+	req = httptest.NewRequest(http.MethodGet, "/api/rounds", nil)
+	w = httptest.NewRecorder()
+	h.HandleRounds(w, req)
+
+	var rounds []model.Round
+	if err := json.NewDecoder(w.Body).Decode(&rounds); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(rounds) != 1 {
+		t.Fatalf("expected 1 round, got %d", len(rounds))
+	}
+	if len(rounds[0].Shots) != 1 {
+		t.Errorf("expected 1 shot in listed round, got %d", len(rounds[0].Shots))
+	}
+
+	_ = roundStore // suppress unused
 }

--- a/api/internal/handler/recommendation.go
+++ b/api/internal/handler/recommendation.go
@@ -31,20 +31,16 @@ func (h *RecommendationHandler) HandleRecommend(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := req.CurrentPosition.Validate(); err != nil {
-		respondError(w, http.StatusBadRequest, "現在位置が不正です: "+err.Error())
-		return
-	}
-	if err := req.TargetPosition.Validate(); err != nil {
-		respondError(w, http.StatusBadRequest, "ターゲット位置が不正です: "+err.Error())
-		return
-	}
-
 	if req.Hazards == nil {
 		req.Hazards = []model.Hazard{}
 	}
 	if req.Shots == nil {
 		req.Shots = []model.Shot{}
+	}
+
+	if err := req.Validate(); err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	recommendations := h.engine.Recommend(

--- a/api/internal/handler/round.go
+++ b/api/internal/handler/round.go
@@ -10,12 +10,13 @@ import (
 
 // RoundHandler はラウンドAPIのハンドラ。
 type RoundHandler struct {
-	store store.RoundStore
+	store     store.RoundStore
+	shotStore store.ShotStore
 }
 
 // NewRoundHandler は新しいRoundHandlerを作成する。
-func NewRoundHandler(s store.RoundStore) *RoundHandler {
-	return &RoundHandler{store: s}
+func NewRoundHandler(s store.RoundStore, ss store.ShotStore) *RoundHandler {
+	return &RoundHandler{store: s, shotStore: ss}
 }
 
 // HandleRounds は /api/rounds エンドポイントのハンドラ。
@@ -59,6 +60,22 @@ func (h *RoundHandler) listRounds(w http.ResponseWriter, r *http.Request) {
 	if rounds == nil {
 		rounds = []model.Round{}
 	}
+
+	// 各ラウンドにShotStoreのショットを同期する
+	if h.shotStore != nil {
+		for i, round := range rounds {
+			shots, shotErr := h.shotStore.ListByRound(r.Context(), round.ID)
+			if shotErr != nil {
+				respondError(w, http.StatusInternalServerError, "ショットの取得に失敗しました")
+				return
+			}
+			if shots == nil {
+				shots = []model.Shot{}
+			}
+			rounds[i].Shots = shots
+		}
+	}
+
 	respondJSON(w, http.StatusOK, rounds)
 }
 
@@ -68,6 +85,20 @@ func (h *RoundHandler) getRound(w http.ResponseWriter, r *http.Request, id strin
 		respondError(w, http.StatusNotFound, "ラウンドが見つかりません")
 		return
 	}
+
+	// ShotStoreからこのラウンドのショットを動的に取得して同期する
+	if h.shotStore != nil {
+		shots, shotErr := h.shotStore.ListByRound(r.Context(), id)
+		if shotErr != nil {
+			respondError(w, http.StatusInternalServerError, "ショットの取得に失敗しました")
+			return
+		}
+		if shots == nil {
+			shots = []model.Shot{}
+		}
+		round.Shots = shots
+	}
+
 	respondJSON(w, http.StatusOK, round)
 }
 

--- a/api/internal/model/round.go
+++ b/api/internal/model/round.go
@@ -34,20 +34,36 @@ func (r Round) Validate() error {
 }
 
 // ValidateRoundDate はラウンド日時のバリデーションを行う。
+// 日付はAsia/Tokyoタイムゾーンで評価し、未来日チェックは日付文字列のみで比較する。
 func ValidateRoundDate(dateStr string) error {
 	if dateStr == "" {
 		return fmt.Errorf("日付は必須です")
 	}
-	// ISO8601 形式をまず試す
-	t, err := time.Parse(time.RFC3339, dateStr)
+
+	jst, err := time.LoadLocation("Asia/Tokyo")
 	if err != nil {
+		return fmt.Errorf("タイムゾーンの読み込みに失敗しました: %w", err)
+	}
+
+	var dateOnly string
+	// ISO8601 形式をまず試す
+	t, parseErr := time.Parse(time.RFC3339, dateStr)
+	if parseErr != nil {
 		// YYYY-MM-DD 形式を試す
-		t, err = time.Parse("2006-01-02", dateStr)
-		if err != nil {
+		t, parseErr = time.Parse("2006-01-02", dateStr)
+		if parseErr != nil {
 			return fmt.Errorf("有効な日付を指定してください")
 		}
+		dateOnly = dateStr
+	} else {
+		// RFC3339の場合、JSTでの日付部分を取得
+		_ = t // suppress unused warning
+		dateOnly = t.In(jst).Format("2006-01-02")
 	}
-	if t.After(time.Now()) {
+
+	// 今日の日付（JST）と文字列比較で未来日チェック
+	todayStr := time.Now().In(jst).Format("2006-01-02")
+	if dateOnly > todayStr {
 		return fmt.Errorf("未来日のラウンドは登録できません")
 	}
 	return nil

--- a/api/internal/model/round_test.go
+++ b/api/internal/model/round_test.go
@@ -14,9 +14,12 @@ func TestValidateRoundDate(t *testing.T) {
 	}{
 		{"有効な日付 (YYYY-MM-DD)", "2025-01-01", false},
 		{"有効な日付 (ISO8601)", "2025-01-01T00:00:00Z", false},
+		{"有効な日付 (ISO8601 JST)", "2025-01-01T09:00:00+09:00", false},
 		{"未来日", "2099-12-31T00:00:00Z", true},
 		{"不正な形式", "not-a-date", true},
 		{"空文字", "", true},
+		// UTC midnight = JST 翌日の場合でも日付部分で判定する
+		{"今日のUTC midnight", "2025-06-01T00:00:00Z", false},
 	}
 
 	for _, tt := range tests {

--- a/api/internal/model/statistics.go
+++ b/api/internal/model/statistics.go
@@ -1,5 +1,7 @@
 package model
 
+import "fmt"
+
 // DistanceStats はクラブ別飛距離統計結果。
 type DistanceStats struct {
 	ClubType ClubType `json:"clubType"`
@@ -29,4 +31,38 @@ type RecommendRequest struct {
 	Hazards         []Hazard   `json:"hazards"`
 	Shots           []Shot     `json:"shots"`
 	RoundCount      int        `json:"roundCount"`
+}
+
+// Validate はRecommendRequestのバリデーションを行う。
+func (r RecommendRequest) Validate() error {
+	if err := r.CurrentPosition.Validate(); err != nil {
+		return fmt.Errorf("現在位置が不正です: %w", err)
+	}
+	if err := r.TargetPosition.Validate(); err != nil {
+		return fmt.Errorf("ターゲット位置が不正です: %w", err)
+	}
+
+	for i, h := range r.Hazards {
+		if !IsValidHazardType(string(h.Type)) {
+			return fmt.Errorf("ハザード[%d]: 無効なハザード種別です: %s", i, h.Type)
+		}
+		if h.RadiusYards < 0 {
+			return fmt.Errorf("ハザード[%d]: 半径は0以上で指定してください", i)
+		}
+	}
+
+	for i, s := range r.Shots {
+		if !IsValidClubType(string(s.Club)) {
+			return fmt.Errorf("ショット[%d]: 無効なクラブ種別です: %s", i, s.Club)
+		}
+		if s.DistanceYards < 0 {
+			return fmt.Errorf("ショット[%d]: 飛距離は0以上で指定してください", i)
+		}
+	}
+
+	if r.RoundCount < 0 {
+		return fmt.Errorf("ラウンド数は0以上で指定してください")
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- **P1**: `POST /api/shots` で作成したショットが `GET /api/rounds/:id` の `shots` に反映されない問題を修正。`RoundHandler` に `ShotStore` を注入し、`getRound` / `listRounds` で `ShotStore` からショットを動的取得して同期
- **P2-1**: `ValidateRoundDate` で日付を UTC midnight として解釈していた問題を修正。Asia/Tokyo タイムゾーンで日付をパースし、日付文字列のみで未来日比較するよう変更
- **P2-2**: `/api/recommend` の入力バリデーション不足を修正。`RecommendRequest.Validate()` メソッドを新設し、club 名の検証、`distanceYards` の正数チェック、`hazard.type` の検証を追加
- **P3**: `/api/health` の 405 レスポンスが `text/plain` だった問題を修正。JSON 形式 (`application/json`) でエラーを返すよう変更

## Test plan
- [x] Go API テスト全パス (handler, model, service, store, middleware)
- [x] `TestRoundHandler_ShotSync` で Round/Shot 同期を検証
- [x] `TestRecommendationHandler` に不正クラブ種別・負飛距離・不正ハザード種別のテスト追加
- [x] `TestValidateRoundDate` に ISO8601 JST 形式のテスト追加
- [x] フロントエンド TypeScript 型チェック・lint・テスト全パス
- [x] Go race detector 付きテスト全パス