### PR TITLE
fix: 全POSTハンドラにhttp.MaxBytesReader追加(OOM防止)

### DIFF
--- a/api/internal/handler/handler_test.go
+++ b/api/internal/handler/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ryusei/fairway-caddie/api/internal/handler"
@@ -562,4 +563,84 @@ func TestRoundHandler_ShotSync(t *testing.T) {
 	}
 
 	_ = roundStore // suppress unused
+}
+
+// oversizedJSONBody は制限超過のJSONボディを生成する。
+// 有効なJSON形式で1MB超のボディを作るため、巨大な文字列値を持つオブジェクトを構築する。
+func oversizedJSONBody() string {
+	// {"pad":"AAAA..."} 形式で 2MB 相当のJSONを構築
+	return `{"pad":"` + strings.Repeat("A", 2<<20) + `"}`
+}
+
+func TestMaxBytesReader_Shot(t *testing.T) {
+	h, _ := setupShotHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/shots", strings.NewReader(oversizedJSONBody()))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleShots(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("POST /api/shots with oversized body status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestMaxBytesReader_Round(t *testing.T) {
+	h, _, _ := setupRoundHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/rounds", strings.NewReader(oversizedJSONBody()))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleRounds(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("POST /api/rounds with oversized body status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestMaxBytesReader_Recommend(t *testing.T) {
+	engine := service.NewRecommendationService(5)
+	h := handler.NewRecommendationHandler(engine)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/recommend", strings.NewReader(oversizedJSONBody()))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleRecommend(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("POST /api/recommend with oversized body status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestMaxBytesReader_ShotUpdate(t *testing.T) {
+	h, s := setupShotHandler()
+	if _, err := s.Create(nil, validShot()); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/shots/shot-1", strings.NewReader(oversizedJSONBody()))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleShotByID(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("PUT /api/shots/shot-1 with oversized body status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestMaxBytesReader_RoundUpdate(t *testing.T) {
+	h, s, _ := setupRoundHandler()
+	round := validRound()
+	if _, err := s.Create(nil, round); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/rounds/round-1", strings.NewReader(oversizedJSONBody()))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleRoundByID(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("PUT /api/rounds/round-1 with oversized body status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
 }

--- a/api/internal/handler/recommendation.go
+++ b/api/internal/handler/recommendation.go
@@ -25,8 +25,14 @@ func (h *RecommendationHandler) HandleRecommend(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	limitRequestBody(w, r)
+
 	var req model.RecommendRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if isMaxBytesError(err) {
+			respondError(w, http.StatusRequestEntityTooLarge, "リクエストボディが大きすぎます")
+			return
+		}
 		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
 		return
 	}

--- a/api/internal/handler/response.go
+++ b/api/internal/handler/response.go
@@ -2,8 +2,25 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 )
+
+// maxRequestBodySize はリクエストボディの最大サイズ (1MB)。
+const maxRequestBodySize = 1 << 20
+
+// limitRequestBody はリクエストボディのサイズを制限する。
+// 制限を超えた場合は413エラーレスポンスを返してfalseを返す。
+func limitRequestBody(w http.ResponseWriter, r *http.Request) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	return true
+}
+
+// isMaxBytesError はMaxBytesReaderによるサイズ超過エラーかを判定する。
+func isMaxBytesError(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+	return errors.As(err, &maxBytesErr)
+}
 
 // ErrorResponse はAPIエラーレスポンス。
 type ErrorResponse struct {

--- a/api/internal/handler/round.go
+++ b/api/internal/handler/round.go
@@ -103,8 +103,14 @@ func (h *RoundHandler) getRound(w http.ResponseWriter, r *http.Request, id strin
 }
 
 func (h *RoundHandler) createRound(w http.ResponseWriter, r *http.Request) {
+	limitRequestBody(w, r)
+
 	var round model.Round
 	if err := json.NewDecoder(r.Body).Decode(&round); err != nil {
+		if isMaxBytesError(err) {
+			respondError(w, http.StatusRequestEntityTooLarge, "リクエストボディが大きすぎます")
+			return
+		}
 		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
 		return
 	}
@@ -123,8 +129,14 @@ func (h *RoundHandler) createRound(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *RoundHandler) updateRound(w http.ResponseWriter, r *http.Request, id string) {
+	limitRequestBody(w, r)
+
 	var round model.Round
 	if err := json.NewDecoder(r.Body).Decode(&round); err != nil {
+		if isMaxBytesError(err) {
+			respondError(w, http.StatusRequestEntityTooLarge, "リクエストボディが大きすぎます")
+			return
+		}
 		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
 		return
 	}

--- a/api/internal/handler/shot.go
+++ b/api/internal/handler/shot.go
@@ -82,8 +82,14 @@ func (h *ShotHandler) getShot(w http.ResponseWriter, r *http.Request, id string)
 }
 
 func (h *ShotHandler) createShot(w http.ResponseWriter, r *http.Request) {
+	limitRequestBody(w, r)
+
 	var shot model.Shot
 	if err := json.NewDecoder(r.Body).Decode(&shot); err != nil {
+		if isMaxBytesError(err) {
+			respondError(w, http.StatusRequestEntityTooLarge, "リクエストボディが大きすぎます")
+			return
+		}
 		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
 		return
 	}
@@ -102,8 +108,14 @@ func (h *ShotHandler) createShot(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *ShotHandler) updateShot(w http.ResponseWriter, r *http.Request, id string) {
+	limitRequestBody(w, r)
+
 	var shot model.Shot
 	if err := json.NewDecoder(r.Body).Decode(&shot); err != nil {
+		if isMaxBytesError(err) {
+			respondError(w, http.StatusRequestEntityTooLarge, "リクエストボディが大きすぎます")
+			return
+		}
 		respondError(w, http.StatusBadRequest, "リクエストボディのパースに失敗しました")
 		return
 	}


### PR DESCRIPTION
## Summary
- 全てのPOST/PUTハンドラ（shot, round, recommend）に`http.MaxBytesReader`(1MB制限)を追加
- 巨大リクエストボディによるOOM攻撃を防止
- 制限超過時は413 Request Entity Too Largeを返却
- 共通ヘルパー `limitRequestBody()` と `isMaxBytesError()` を `response.go` に追加

## Test plan
- [x] 各ハンドラの2MB超過ボディテスト追加（5件）
- [x] 既存テスト全パス確認
- [x] `go build ./...` 成功