### PR TITLE
fix: Round/Shot読み書き契約を統一

### DIFF
--- a/api/internal/handler/handler_test.go
+++ b/api/internal/handler/handler_test.go
@@ -565,6 +565,91 @@ func TestRoundHandler_ShotSync(t *testing.T) {
 	_ = roundStore // suppress unused
 }
 
+func TestRoundHandler_CreateWithShotsSync(t *testing.T) {
+	h, _, shotStore := setupRoundHandler()
+
+	// ショット付きのラウンドを作成
+	shot := validShot()
+	round := validRound()
+	round.Shots = []model.Shot{shot}
+
+	body, marshalErr := json.Marshal(round)
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/rounds", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleRounds(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST /api/rounds status = %d, want %d. Body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	// レスポンスにショットが含まれることを確認
+	var createdRound model.Round
+	if err := json.NewDecoder(w.Body).Decode(&createdRound); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(createdRound.Shots) != 1 {
+		t.Errorf("expected 1 shot in created round response, got %d", len(createdRound.Shots))
+	}
+
+	// shotStoreにも同期されていることを確認
+	shots, err := shotStore.ListByRound(nil, round.ID)
+	if err != nil {
+		t.Fatalf("shotStore.ListByRound error: %v", err)
+	}
+	if len(shots) != 1 {
+		t.Errorf("expected 1 shot in shotStore, got %d", len(shots))
+	}
+}
+
+func TestRoundHandler_UpdateWithShotsSync(t *testing.T) {
+	h, roundStore, shotStore := setupRoundHandler()
+
+	// まずラウンドを作成（ショットなし）
+	round := validRound()
+	if _, err := roundStore.Create(nil, round); err != nil {
+		t.Fatalf("setup error: %v", err)
+	}
+
+	// ショット付きでPUT更新
+	shot := validShot()
+	round.Shots = []model.Shot{shot}
+
+	body, marshalErr := json.Marshal(round)
+	if marshalErr != nil {
+		t.Fatalf("marshal error: %v", marshalErr)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/api/rounds/round-1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleRoundByID(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT /api/rounds/round-1 status = %d, want %d. Body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// レスポンスにショットが含まれることを確認
+	var updatedRound model.Round
+	if err := json.NewDecoder(w.Body).Decode(&updatedRound); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(updatedRound.Shots) != 1 {
+		t.Errorf("expected 1 shot in updated round response, got %d", len(updatedRound.Shots))
+	}
+
+	// shotStoreにも同期されていることを確認
+	shots, err := shotStore.ListByRound(nil, round.ID)
+	if err != nil {
+		t.Fatalf("shotStore.ListByRound error: %v", err)
+	}
+	if len(shots) != 1 {
+		t.Errorf("expected 1 shot in shotStore, got %d", len(shots))
+	}
+}
+
 // oversizedJSONBody は制限超過のJSONボディを生成する。
 // 有効なJSON形式で1MB超のボディを作るため、巨大な文字列値を持つオブジェクトを構築する。
 func oversizedJSONBody() string {

--- a/api/internal/handler/round.go
+++ b/api/internal/handler/round.go
@@ -120,11 +120,41 @@ func (h *RoundHandler) createRound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ShotsをshotStoreに同期するため退避し、roundStoreには保存しない
+	shotsToSync := round.Shots
+	round.Shots = nil
+
 	created, err := h.store.Create(r.Context(), round)
 	if err != nil {
 		respondError(w, http.StatusConflict, err.Error())
 		return
 	}
+
+	// リクエストに含まれるショットをshotStoreに同期
+	if h.shotStore != nil {
+		for _, shot := range shotsToSync {
+			shot.RoundID = created.ID
+			if _, syncErr := h.shotStore.Create(r.Context(), shot); syncErr != nil {
+				// 重複IDは無視（既にshotStoreに存在する場合）
+				continue
+			}
+		}
+	}
+
+	// レスポンスにはshotStoreのショットを反映
+	if h.shotStore != nil {
+		shots, shotErr := h.shotStore.ListByRound(r.Context(), created.ID)
+		if shotErr == nil {
+			if shots == nil {
+				shots = []model.Shot{}
+			}
+			created.Shots = shots
+		}
+	}
+	if created.Shots == nil {
+		created.Shots = []model.Shot{}
+	}
+
 	respondJSON(w, http.StatusCreated, created)
 }
 
@@ -147,11 +177,43 @@ func (h *RoundHandler) updateRound(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 
+	// ShotsをshotStoreに同期するため退避し、roundStoreには保存しない
+	shotsToSync := round.Shots
+	round.Shots = nil
+
 	updated, err := h.store.Update(r.Context(), round)
 	if err != nil {
 		respondError(w, http.StatusNotFound, err.Error())
 		return
 	}
+
+	// リクエストに含まれるショットをshotStoreに同期
+	if h.shotStore != nil {
+		for _, shot := range shotsToSync {
+			shot.RoundID = updated.ID
+			// 既存のショットは更新、新規は作成
+			if _, syncErr := h.shotStore.Update(r.Context(), shot); syncErr != nil {
+				if _, createErr := h.shotStore.Create(r.Context(), shot); createErr != nil {
+					continue
+				}
+			}
+		}
+	}
+
+	// レスポンスにはshotStoreのショットを反映
+	if h.shotStore != nil {
+		shots, shotErr := h.shotStore.ListByRound(r.Context(), updated.ID)
+		if shotErr == nil {
+			if shots == nil {
+				shots = []model.Shot{}
+			}
+			updated.Shots = shots
+		}
+	}
+	if updated.Shots == nil {
+		updated.Shots = []model.Shot{}
+	}
+
 	respondJSON(w, http.StatusOK, updated)
 }
 


### PR DESCRIPTION
## Summary
- createRound/updateRoundでリクエストボディに含まれるShotsをshotStoreに同期
- roundStoreにはShotsを保存せず、常にshotStore経由で取得する設計に統一
- レスポンスにもshotStoreのショットを反映

## Test plan
- [x] ショット付きラウンド作成→shotStoreに同期されることを確認
- [x] ショット付きラウンド更新→shotStoreに同期されることを確認
- [x] 既存テスト全パス確認
- [x] `go build ./...` 成功