### PR TITLE
fix: テスト日付を動的に変更しJST/UTC境界検証追加

### DIFF
--- a/api/internal/handler/handler_test.go
+++ b/api/internal/handler/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ryusei/fairway-caddie/api/internal/handler"
 	"github.com/ryusei/fairway-caddie/api/internal/model"
@@ -41,11 +42,19 @@ func validShot() model.Shot {
 	}
 }
 
+func todayJST() string {
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		panic("タイムゾーンの読み込みに失敗: " + err.Error())
+	}
+	return time.Now().In(jst).Format("2006-01-02")
+}
+
 func validRound() model.Round {
 	return model.Round{
 		ID:       "round-1",
 		CourseID: "mock-course-001",
-		Date:     "2025-06-01",
+		Date:     todayJST(),
 		Shots:    []model.Shot{},
 	}
 }

--- a/api/internal/model/round_test.go
+++ b/api/internal/model/round_test.go
@@ -1,25 +1,37 @@
 package model_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/ryusei/fairway-caddie/api/internal/model"
 )
 
 func TestValidateRoundDate(t *testing.T) {
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("タイムゾーンの読み込みに失敗: %v", err)
+	}
+
+	now := time.Now()
+	today := now.In(jst).Format("2006-01-02")
+	yesterday := now.In(jst).AddDate(0, 0, -1).Format("2006-01-02")
+	tomorrow := now.In(jst).AddDate(0, 0, 1).Format("2006-01-02")
+
 	tests := []struct {
 		name    string
 		date    string
 		wantErr bool
 	}{
-		{"有効な日付 (YYYY-MM-DD)", "2025-01-01", false},
-		{"有効な日付 (ISO8601)", "2025-01-01T00:00:00Z", false},
-		{"有効な日付 (ISO8601 JST)", "2025-01-01T09:00:00+09:00", false},
-		{"未来日", "2099-12-31T00:00:00Z", true},
+		{"今日の日付 (YYYY-MM-DD)", today, false},
+		{"昨日の日付 (YYYY-MM-DD)", yesterday, false},
+		{"過去日 (ISO8601)", yesterday + "T09:00:00+09:00", false},
+		{"今日のISO8601 JST", today + "T09:00:00+09:00", false},
+		{"明日の日付 (未来日)", tomorrow, true},
+		{"遠い未来日", "2099-12-31T00:00:00Z", true},
 		{"不正な形式", "not-a-date", true},
 		{"空文字", "", true},
-		// UTC midnight = JST 翌日の場合でも日付部分で判定する
-		{"今日のUTC midnight", "2025-06-01T00:00:00Z", false},
 	}
 
 	for _, tt := range tests {
@@ -32,12 +44,89 @@ func TestValidateRoundDate(t *testing.T) {
 	}
 }
 
+func TestValidateRoundDate_UTCJSTBoundary(t *testing.T) {
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("タイムゾーンの読み込みに失敗: %v", err)
+	}
+
+	now := time.Now()
+	todayJST := now.In(jst).Format("2006-01-02")
+	yesterdayJST := now.In(jst).AddDate(0, 0, -1).Format("2006-01-02")
+
+	t.Run("UTC midnight今日 → JSTでは今日", func(t *testing.T) {
+		// 今日のUTC 00:00:00 → JSTでは今日の09:00:00
+		dateStr := todayJST + "T00:00:00+09:00"
+		err := model.ValidateRoundDate(dateStr)
+		if err != nil {
+			t.Errorf("ValidateRoundDate(%q) unexpected error: %v", dateStr, err)
+		}
+	})
+
+	t.Run("UTC深夜の昨日 → JSTでも昨日", func(t *testing.T) {
+		// 昨日のJST 23:59:59
+		dateStr := yesterdayJST + "T23:59:59+09:00"
+		err := model.ValidateRoundDate(dateStr)
+		if err != nil {
+			t.Errorf("ValidateRoundDate(%q) unexpected error: %v", dateStr, err)
+		}
+	})
+
+	t.Run("UTC 15:00今日 = JST翌日0:00 → JSTの日付で判定", func(t *testing.T) {
+		// 今日のUTC 15:00 → JSTでは翌日の00:00
+		// JSTでの日付が明日になるため未来日エラーになるべき
+		dateStr := fmt.Sprintf("%sT15:00:00Z", todayJST)
+		// UTC 15:00 → JST 翌日00:00
+		parsed, parseErr := time.Parse(time.RFC3339, dateStr)
+		if parseErr != nil {
+			t.Fatalf("parse error: %v", parseErr)
+		}
+		jstDate := parsed.In(jst).Format("2006-01-02")
+		tomorrow := now.In(jst).AddDate(0, 0, 1).Format("2006-01-02")
+
+		err := model.ValidateRoundDate(dateStr)
+		if jstDate == tomorrow {
+			// JSTで翌日に跨いでいる場合はエラーが期待される
+			if err == nil {
+				t.Errorf("ValidateRoundDate(%q) should return error: JST date=%s is tomorrow", dateStr, jstDate)
+			}
+		} else {
+			// JSTでまだ今日の場合はエラーなし
+			if err != nil {
+				t.Errorf("ValidateRoundDate(%q) unexpected error: %v (JST date=%s)", dateStr, err, jstDate)
+			}
+		}
+	})
+
+	t.Run("早朝UTCは前日JST → 過去日として有効", func(t *testing.T) {
+		// 昨日のUTC 20:00 → JSTでは今日の05:00
+		dateStr := fmt.Sprintf("%sT20:00:00Z", yesterdayJST)
+		parsed, parseErr := time.Parse(time.RFC3339, dateStr)
+		if parseErr != nil {
+			t.Fatalf("parse error: %v", parseErr)
+		}
+		jstDate := parsed.In(jst).Format("2006-01-02")
+		_ = jstDate // JSTでの日付を確認
+
+		err := model.ValidateRoundDate(dateStr)
+		if err != nil {
+			t.Errorf("ValidateRoundDate(%q) unexpected error: %v", dateStr, err)
+		}
+	})
+}
+
 func TestRoundValidate(t *testing.T) {
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatalf("タイムゾーンの読み込みに失敗: %v", err)
+	}
+	today := time.Now().In(jst).Format("2006-01-02")
+
 	t.Run("有効なラウンド", func(t *testing.T) {
 		round := model.Round{
 			ID:       "round-1",
 			CourseID: "course-1",
-			Date:     "2025-06-01",
+			Date:     today,
 			Shots:    []model.Shot{},
 		}
 		if err := round.Validate(); err != nil {
@@ -49,7 +138,7 @@ func TestRoundValidate(t *testing.T) {
 		round := model.Round{
 			ID:       "",
 			CourseID: "course-1",
-			Date:     "2025-06-01",
+			Date:     today,
 		}
 		if err := round.Validate(); err == nil {
 			t.Error("Validate() should return error for empty ID")
@@ -60,7 +149,7 @@ func TestRoundValidate(t *testing.T) {
 		round := model.Round{
 			ID:       "round-1",
 			CourseID: "",
-			Date:     "2025-06-01",
+			Date:     today,
 		}
 		if err := round.Validate(); err == nil {
 			t.Error("Validate() should return error for empty CourseID")


### PR DESCRIPTION
## Summary
- 固定日付テスト(`2025-01-01`等)を`time.Now()`ベースの動的日付に変更
- JST/UTC間の日付跨ぎ境界条件テストを追加（4ケース）
- handler_test.goの`validRound()`も動的日付に変更

## Test plan
- [x] 今日/昨日/明日のテストケース → テスト実行日に依存しない
- [x] UTC midnight → JST変換テスト
- [x] UTC 15:00 → JST翌日0:00 跨ぎテスト
- [x] 既存テスト全パス確認
- [x] `go build ./...` 成功