### PR TITLE
fix: CIにGo APIテストジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,26 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  go-api:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: api/go.mod
+
+      - name: Build
+        working-directory: api
+        run: go build ./...
+
+      - name: Vet
+        working-directory: api
+        run: go vet ./...
+
+      - name: Test
+        working-directory: api
+        run: go test -race -count=1 ./...


### PR DESCRIPTION
## Summary
- CIワークフロー(ci.yml)にGo APIのビルド・vet・テストを実行するgo-apiジョブを追加
- フロントエンドとGoバックエンドの品質を両方CIで担保する

## 背景
Go APIのコードに回帰バグが入ってもCIで検出できない状態だった。

## Test plan
- [ ] CIのgo-apiジョブが正常に実行される
- [ ] 既存のcheckジョブに影響がない