### PR TITLE
fix: CourseStoreにRWMutex追加・recordShot複雑度低減

### DIFF
--- a/api/internal/store/memory.go
+++ b/api/internal/store/memory.go
@@ -202,6 +202,7 @@ func (s *MemoryRoundStore) Count(_ context.Context) (int, error) {
 
 // MemoryCourseStore はインメモリのコースストア（モックデータ付き）。
 type MemoryCourseStore struct {
+	mu      sync.RWMutex
 	courses map[string]model.Course
 	order   []string
 }
@@ -246,6 +247,8 @@ func NewMemoryCourseStore() *MemoryCourseStore {
 }
 
 func (s *MemoryCourseStore) List(_ context.Context) ([]model.Course, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	result := make([]model.Course, 0, len(s.order))
 	for _, id := range s.order {
 		if course, ok := s.courses[id]; ok {
@@ -256,6 +259,8 @@ func (s *MemoryCourseStore) List(_ context.Context) ([]model.Course, error) {
 }
 
 func (s *MemoryCourseStore) GetByID(_ context.Context, id string) (model.Course, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	course, ok := s.courses[id]
 	if !ok {
 		return model.Course{}, fmt.Errorf("コースが見つかりません: %s", id)

--- a/src/hooks/useRound.ts
+++ b/src/hooks/useRound.ts
@@ -21,6 +21,35 @@ function generateId(): string {
 	return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+/** ショットの原点座標を決定する */
+function resolveOrigin(lastShotPosition: Coordinate | null, courseId: string, holeNumber: number): Coordinate | null {
+	if (lastShotPosition) return lastShotPosition;
+	return getTeePosition(courseId, holeNumber) ?? null;
+}
+
+/** ショットオブジェクトを構築する */
+function buildShot(
+	round: Round,
+	club: ClubType,
+	position: Coordinate,
+	origin: Coordinate | null,
+	holeNumber: number,
+	shotNumber: number,
+): Shot {
+	const distanceYards = origin ? euclideanDistanceYards(origin, position) : 0;
+	return {
+		id: generateId(),
+		roundId: round.id,
+		holeNumber,
+		shotNumber,
+		club,
+		position: origin ?? position,
+		landingPosition: position,
+		distanceYards: Math.round(distanceYards),
+		timestamp: new Date().toISOString(),
+	};
+}
+
 export interface UseRoundReturn {
 	readonly round: Round | null;
 	readonly selectedClub: ClubType | null;
@@ -65,37 +94,15 @@ export function useRound(): UseRoundReturn {
 
 			const shotNumber = round.shots.filter((s) => s.holeNumber === currentHole).length + 1;
 
-			// 飛距離: 前のショットの着弾位置からユークリッド距離で計算
-			// 最初のショットはティー位置から計算する
-			let origin = lastShotPosition;
-			if (!origin) {
-				const teePos = getTeePosition(round.courseId, currentHole);
-				if (teePos) {
-					origin = teePos;
-				}
-			}
+			const origin = resolveOrigin(lastShotPosition, round.courseId, currentHole);
 			const distanceYards = origin ? euclideanDistanceYards(origin, position) : 0;
 
 			const distanceError = validateDistance(distanceYards);
 			if (distanceError) return distanceError;
 
-			const shot: Shot = {
-				id: generateId(),
-				roundId: round.id,
-				holeNumber: currentHole,
-				shotNumber,
-				club: selectedClub,
-				position: origin ?? position,
-				landingPosition: position,
-				distanceYards: Math.round(distanceYards),
-				timestamp: new Date().toISOString(),
-			};
+			const shot = buildShot(round, selectedClub, position, origin, currentHole, shotNumber);
 
-			const updatedRound: Round = {
-				...round,
-				shots: [...round.shots, shot],
-			};
-			setRound(updatedRound);
+			setRound({ ...round, shots: [...round.shots, shot] });
 			setLastShotPosition(position);
 			return null;
 		},


### PR DESCRIPTION
## Summary
- MemoryCourseStoreにsync.RWMutexを追加し並行アクセス安全性を担保
- useRound.tsのrecordShot関数をresolveOrigin/buildShotに分割し認知的複雑度を15以下に低減
- biomeのcognitive complexity警告を解消

## Test plan
- [ ] Go APIテスト全パス (go test -race -count=1 ./...)
- [ ] フロントエンドテスト全パス (vitest run)
- [ ] biome check警告ゼロ
- [ ] CI全ジョブ通過